### PR TITLE
Align Kotlin JVM target with Java for the buildscript

### DIFF
--- a/tools/build-config/build.gradle.kts
+++ b/tools/build-config/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
@@ -26,6 +28,12 @@ tasks.validatePlugins {
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
 }
 
 gradlePlugin {


### PR DESCRIPTION
### What does this PR do?

Minor change to align targets between Kotlin and Java for the buildscript, otherwise iOS app build from XCode doesn't work (it calls Gradle task as a build step), while working from Android Studio by some reason.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

