### PR TITLE
RUM-4295: Add methods to set user info, tracking consent and clear data

### DIFF
--- a/dd-sdk-kotlin-multiplatform-core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/dd-sdk-kotlin-multiplatform-core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -22,6 +22,7 @@ import com.datadog.android.core.configuration.UploadFrequency as UploadFrequency
 import com.datadog.android.privacy.TrackingConsent as TrackingConsentAndroid
 
 actual object Datadog {
+
     actual var verbosity: LogLevel?
         get() = DatadogAndroid.getVerbosity().toLogLevel
         set(value) = DatadogAndroid.setVerbosity(value.native)
@@ -33,6 +34,23 @@ actual object Datadog {
     ) {
         requireNotNull(context)
         DatadogAndroid.initialize(context as Context, configuration.native, trackingConsent.native)
+    }
+
+    actual fun setTrackingConsent(consent: TrackingConsent) {
+        DatadogAndroid.setTrackingConsent(consent.native)
+    }
+
+    actual fun setUserInfo(
+        id: String?,
+        name: String?,
+        email: String?,
+        extraInfo: Map<String, Any?>
+    ) {
+        DatadogAndroid.setUserInfo(id, name, email, extraInfo)
+    }
+
+    actual fun clearAllData() {
+        DatadogAndroid.clearAllData()
     }
 }
 

--- a/dd-sdk-kotlin-multiplatform-core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/dd-sdk-kotlin-multiplatform-core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -40,4 +40,33 @@ expect object Datadog {
         configuration: Configuration,
         trackingConsent: TrackingConsent
     )
+
+    /**
+     * Sets the tracking consent regarding the data collection for this instance of the Datadog SDK.
+     *
+     * @param consent which can take one of the values
+     * ([TrackingConsent.PENDING], [TrackingConsent.GRANTED], [TrackingConsent.NOT_GRANTED])
+     */
+    fun setTrackingConsent(consent: TrackingConsent)
+
+    /**
+     * Sets the user information.
+     *
+     * @param id (nullable) a unique user identifier (relevant to your business domain)
+     * @param name (nullable) the user name or alias
+     * @param email (nullable) the user email
+     * @param extraInfo additional information. An extra information can be
+     * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
+     */
+    fun setUserInfo(
+        id: String? = null,
+        name: String? = null,
+        email: String? = null,
+        extraInfo: Map<String, Any?> = emptyMap()
+    )
+
+    /**
+     * Clears all unsent data in all registered features.
+     */
+    fun clearAllData()
 }

--- a/dd-sdk-kotlin-multiplatform-core/src/iosMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/dd-sdk-kotlin-multiplatform-core/src/iosMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -4,8 +4,6 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-@file:OptIn(ExperimentalForeignApi::class)
-
 package com.datadog.kmp
 
 import cocoapods.DatadogObjc.DDBatchProcessingLevelHigh
@@ -31,10 +29,10 @@ import com.datadog.kmp.core.configuration.BatchSize
 import com.datadog.kmp.core.configuration.Configuration
 import com.datadog.kmp.core.configuration.UploadFrequency
 import com.datadog.kmp.privacy.TrackingConsent
-import kotlinx.cinterop.ExperimentalForeignApi
 import cocoapods.DatadogObjc.DDDatadog as DatadogIOS
 
 actual object Datadog {
+
     actual var verbosity: LogLevel?
         get() = DatadogIOS.verbosityLevel().toLogLevel
         set(value) = DatadogIOS.setVerbosityLevel(value.native)
@@ -46,6 +44,33 @@ actual object Datadog {
         trackingConsent: TrackingConsent
     ) {
         DatadogIOS.initializeWithConfiguration(configuration.native, trackingConsent.native)
+    }
+
+    actual fun setTrackingConsent(consent: TrackingConsent) {
+        DatadogIOS.setTrackingConsentWithConsent(consent.native)
+    }
+
+    actual fun setUserInfo(
+        id: String?,
+        name: String?,
+        email: String?,
+        extraInfo: Map<String, Any?>
+    ) {
+        DatadogIOS.setUserInfoWithId(
+            id,
+            name,
+            email,
+            extraInfo.mapKeys {
+                // in reality in ObjC it is extraInfo: [String: Any], but KMP generates the
+                // signature extraInfo: Map<kotlin.Any?, *>, erasing String type
+                @Suppress("USELESS_CAST")
+                it.key as Any
+            }
+        )
+    }
+
+    actual fun clearAllData() {
+        DatadogIOS.clearAllData()
     }
 }
 

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
@@ -11,6 +11,7 @@ import com.datadog.kmp.LogLevel
 import com.datadog.kmp.core.configuration.Configuration
 import com.datadog.kmp.privacy.TrackingConsent
 
+@Suppress("MagicNumber")
 fun initDatadog(context: Any? = null) {
     Datadog.verbosity = LogLevel.DEBUG
 
@@ -20,4 +21,10 @@ fun initDatadog(context: Any? = null) {
     ).build()
 
     Datadog.initialize(context = context, configuration = configuration, trackingConsent = TrackingConsent.GRANTED)
+
+    Datadog.setUserInfo(
+        name = "Random User",
+        email = "user@example.com",
+        extraInfo = mapOf("age" to 42, "location" to "universe")
+    )
 }

--- a/tools/build-config/src/main/kotlin/com/datadog/build/DatadogProjectConfigurationPlugin.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/build/DatadogProjectConfigurationPlugin.kt
@@ -76,6 +76,12 @@ private fun Project.applyKotlinMultiplatformConfig(configExtension: DatadogBuild
             iosArm64()
             iosSimulatorArm64()
 
+            sourceSets.all {
+                if (name.startsWith("ios")) {
+                    languageSettings.optIn("kotlinx.cinterop.ExperimentalForeignApi")
+                }
+            }
+
             targets.all {
                 compilations.all {
                     kotlinOptions {


### PR DESCRIPTION
### What does this PR do?

This PR adds methods to set user info, tracking consent and clear data, making `Datadog` class almost complete (other methods require APIs to be added on the iOS SDK ObjC side, see https://github.com/DataDog/dd-sdk-ios/pull/1799 and https://github.com/DataDog/dd-sdk-ios/pull/1800).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

