### PR TITLE
Update iOS SDK to 2.10.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,7 @@ compose-compiler = "1.5.12"
 compose-material3 = "1.1.2"
 androidx-activityCompose = "1.8.0"
 datadog-android = "2.8.0"
-# TODO RUM-4282 Cannot use 2.7.0 and above, because KMP plugin breaks if there is privacy manifest included
-datadog-ios = "2.6.0"
+datadog-ios = "2.10.0"
 dependencyLicense = "0.2"
 
 [libraries]


### PR DESCRIPTION
### What does this PR do?

This PR updates iOS SDK to version `2.10.0`. By some reason there are no issues building the sample app anymore when Datadog dependency comes with privacy manifest.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

