### PR TITLE
RUM-4504: Add public API surface generator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,14 +14,22 @@ plugins {
     alias(libs.plugins.dependencyLicense) apply false
 }
 
-allprojects {
-    repositories {
-        mavenCentral()
-        google()
-    }
-}
-
 /**
  * Task necessary to be compliant with the shared Android static analysis pipeline
  */
 tasks.register("checkGeneratedFiles") { }
+
+fun registerApiSurfaceAggregationTask(aggregationTaskName: String, projectTaskName: String) {
+    tasks.register(aggregationTaskName) {
+        val aggregationTask = this
+        allprojects.forEach {
+            it.pluginManager.withPlugin("api-surface") {
+                val projectTask = it.tasks.named(projectTaskName)
+                aggregationTask.dependsOn(projectTask)
+            }
+        }
+    }
+}
+
+registerApiSurfaceAggregationTask("checkApiSurfaceChangesAll", "checkApiSurfaceChanges")
+registerApiSurfaceAggregationTask("generateApiSurfaceAll", "generateApiSurface")

--- a/dd-sdk-kotlin-multiplatform-core/api/androidMain/apiSurface
+++ b/dd-sdk-kotlin-multiplatform-core/api/androidMain/apiSurface
@@ -1,0 +1,9 @@
+object com.datadog.kmp.Datadog
+  var verbosity: SdkLogVerbosity?
+  fun initialize(Any?, com.datadog.kmp.core.configuration.Configuration, com.datadog.kmp.privacy.TrackingConsent)
+  fun isInitialized(): Boolean
+  fun setTrackingConsent(com.datadog.kmp.privacy.TrackingConsent)
+  fun setUserInfo(String?, String?, String?, Map<String, Any?>)
+  fun addUserExtraInfo(Map<String, Any?>)
+  fun clearAllData()
+  fun stopInstance()

--- a/dd-sdk-kotlin-multiplatform-core/api/commonMain/apiSurface
+++ b/dd-sdk-kotlin-multiplatform-core/api/commonMain/apiSurface
@@ -1,0 +1,45 @@
+object com.datadog.kmp.Datadog
+  var verbosity: SdkLogVerbosity?
+  fun initialize(Any? = null, com.datadog.kmp.core.configuration.Configuration, com.datadog.kmp.privacy.TrackingConsent)
+  fun isInitialized(): Boolean
+  fun setTrackingConsent(com.datadog.kmp.privacy.TrackingConsent)
+  fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
+  fun addUserExtraInfo(Map<String, Any?>)
+  fun clearAllData()
+  fun stopInstance()
+enum com.datadog.kmp.DatadogSite
+  - US1
+  - US3
+  - US5
+  - EU1
+  - AP1
+  - US1_FED
+enum com.datadog.kmp.SdkLogVerbosity
+  - DEBUG
+  - WARN
+  - ERROR
+  - CRITICAL
+enum com.datadog.kmp.core.configuration.BatchProcessingLevel
+  - LOW
+  - MEDIUM
+  - HIGH
+enum com.datadog.kmp.core.configuration.BatchSize
+  - SMALL
+  - MEDIUM
+  - LARGE
+data class com.datadog.kmp.core.configuration.Configuration
+  class Builder
+    constructor(String, String, String = NO_VARIANT, String? = null)
+    fun build(): Configuration
+    fun useSite(com.datadog.kmp.DatadogSite): Builder
+    fun setBatchSize(BatchSize): Builder
+    fun setUploadFrequency(UploadFrequency): Builder
+    fun setBatchProcessingLevel(BatchProcessingLevel): Builder
+enum com.datadog.kmp.core.configuration.UploadFrequency
+  - FREQUENT
+  - AVERAGE
+  - RARE
+enum com.datadog.kmp.privacy.TrackingConsent
+  - GRANTED
+  - NOT_GRANTED
+  - PENDING

--- a/dd-sdk-kotlin-multiplatform-core/api/iosMain/apiSurface
+++ b/dd-sdk-kotlin-multiplatform-core/api/iosMain/apiSurface
@@ -1,0 +1,9 @@
+object com.datadog.kmp.Datadog
+  var verbosity: SdkLogVerbosity?
+  fun initialize(Any?, com.datadog.kmp.core.configuration.Configuration, com.datadog.kmp.privacy.TrackingConsent)
+  fun isInitialized(): Boolean
+  fun setTrackingConsent(com.datadog.kmp.privacy.TrackingConsent)
+  fun setUserInfo(String?, String?, String?, Map<String, Any?>)
+  fun addUserExtraInfo(Map<String, Any?>)
+  fun clearAllData()
+  fun stopInstance()

--- a/dd-sdk-kotlin-multiplatform-core/build.gradle.kts
+++ b/dd-sdk-kotlin-multiplatform-core/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
     alias(libs.plugins.dependencyLicense)
+    id("api-surface")
 }
 
 kotlin {

--- a/dd-sdk-kotlin-multiplatform-core/src/commonMain/kotlin/com/datadog/kmp/core/configuration/Configuration.kt
+++ b/dd-sdk-kotlin-multiplatform-core/src/commonMain/kotlin/com/datadog/kmp/core/configuration/Configuration.kt
@@ -107,14 +107,14 @@ internal constructor(
 
     // endregion
 
-    companion object {
+    private companion object {
 
         /**
          * Value to use if application doesn't have flavors.
          */
         private const val NO_VARIANT: String = ""
 
-        internal val DEFAULT_CORE_CONFIG = Core(
+        private val DEFAULT_CORE_CONFIG = Core(
             batchSize = BatchSize.MEDIUM,
             uploadFrequency = UploadFrequency.AVERAGE,
             site = DatadogSite.US1,

--- a/features/dd-sdk-kotlin-multiplatform-logs/api/androidMain/apiSurface
+++ b/features/dd-sdk-kotlin-multiplatform-logs/api/androidMain/apiSurface
@@ -1,0 +1,4 @@
+object com.datadog.kmp.log.Logs
+  fun enable()
+  fun addAttribute(String, Any?)
+  fun removeAttribute(String)

--- a/features/dd-sdk-kotlin-multiplatform-logs/api/commonMain/apiSurface
+++ b/features/dd-sdk-kotlin-multiplatform-logs/api/commonMain/apiSurface
@@ -1,0 +1,33 @@
+enum com.datadog.kmp.log.LogLevel
+  - DEBUG
+  - INFO
+  - WARN
+  - ERROR
+  - CRITICAL
+class com.datadog.kmp.log.Logger
+  fun debug(String, Throwable? = null, Map<String, Any?> = emptyMap())
+  fun info(String, Throwable? = null, Map<String, Any?> = emptyMap())
+  fun warn(String, Throwable? = null, Map<String, Any?> = emptyMap())
+  fun error(String, Throwable? = null, Map<String, Any?> = emptyMap())
+  fun critical(String, Throwable? = null, Map<String, Any?> = emptyMap())
+  fun addAttribute(String, Any?)
+  fun removeAttribute(String)
+  fun addTag(String, String)
+  fun addTag(String)
+  fun removeTag(String)
+  fun removeTagsWithKey(String)
+  class Builder
+    constructor()
+    fun build(): Logger
+    fun setService(String): Builder
+    fun setRemoteLogThreshold(LogLevel): Builder
+    fun setPrintLogsToConsole(Boolean): Builder
+    fun setNetworkInfoEnabled(Boolean): Builder
+    fun setName(String): Builder
+    fun setBundleWithTraceEnabled(Boolean): Builder
+    fun setBundleWithRumEnabled(Boolean): Builder
+    fun setRemoteSampleRate(Float): Builder
+object com.datadog.kmp.log.Logs
+  fun enable()
+  fun addAttribute(String, Any?)
+  fun removeAttribute(String)

--- a/features/dd-sdk-kotlin-multiplatform-logs/api/iosMain/apiSurface
+++ b/features/dd-sdk-kotlin-multiplatform-logs/api/iosMain/apiSurface
@@ -1,0 +1,9 @@
+fun Logger.debug(String, platform.Foundation.NSError, Map<String, Any?> = emptyMap())
+fun Logger.info(String, platform.Foundation.NSError, Map<String, Any?> = emptyMap())
+fun Logger.warn(String, platform.Foundation.NSError, Map<String, Any?> = emptyMap())
+fun Logger.error(String, platform.Foundation.NSError, Map<String, Any?> = emptyMap())
+fun Logger.critical(String, platform.Foundation.NSError, Map<String, Any?> = emptyMap())
+object com.datadog.kmp.log.Logs
+  fun enable()
+  fun addAttribute(String, Any?)
+  fun removeAttribute(String)

--- a/features/dd-sdk-kotlin-multiplatform-logs/build.gradle.kts
+++ b/features/dd-sdk-kotlin-multiplatform-logs/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
     alias(libs.plugins.dependencyLicense)
+    id("api-surface")
 }
 
 kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidx-activityCompose = "1.8.0"
 datadog-android = "2.8.0"
 datadog-ios = "2.11.0"
 dependencyLicense = "0.2"
+kotlinGrammarParser = "0.1.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -21,6 +22,7 @@ android-tools = { module = "com.android.tools.build:gradle", version.ref = "agp"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 datadog-android-core = { module = "com.datadoghq:dd-sdk-android-core", version.ref = "datadog-android" }
 datadog-android-logs = { module = "com.datadoghq:dd-sdk-android-logs", version.ref = "datadog-android" }
+kotlinGrammarParser = { module = "com.github.kotlinx.ast:grammar-kotlin-parser-antlr-kotlin-jvm", version.ref = "kotlinGrammarParser" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,12 @@ pluginManagement {
         google()
         gradlePluginPortal()
         mavenCentral()
+        maven {
+            setUrl("https://jitpack.io")
+            mavenContent {
+                includeGroupByRegex("com\\.github\\..*")
+            }
+        }
     }
     includeBuild("./tools/build-config")
 }

--- a/tools/build-config/build.gradle.kts
+++ b/tools/build-config/build.gradle.kts
@@ -13,12 +13,19 @@ plugins {
 repositories {
     google()
     mavenCentral()
+    maven {
+        setUrl("https://jitpack.io")
+        mavenContent {
+            includeGroupByRegex("com\\.github\\..*")
+        }
+    }
 }
 
 dependencies {
     compileOnly(gradleApi())
     compileOnly(libs.android.tools)
     compileOnly(libs.kotlin.gradle.plugin)
+    implementation(libs.kotlinGrammarParser)
 }
 
 tasks.validatePlugins {
@@ -40,7 +47,11 @@ gradlePlugin {
     plugins {
         register("DatadogProjectConfigurationPlugin") {
             id = "datadog-build-config"
-            implementationClass = "com.datadog.build.DatadogProjectConfigurationPlugin"
+            implementationClass = "com.datadog.build.plugin.config.DatadogProjectConfigurationPlugin"
+        }
+        register("ApiSurfacePlugin") {
+            id = "api-surface"
+            implementationClass = "com.datadog.build.plugin.apisurface.ApiSurfacePlugin"
         }
     }
 }

--- a/tools/build-config/src/main/kotlin/com/datadog/build/plugin/apisurface/ApiSurfacePlugin.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/build/plugin/apisurface/ApiSurfacePlugin.kt
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.build.plugin.apisurface
+
+import com.datadog.build.utils.taskConfig
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.File
+
+class ApiSurfacePlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        val commonGenerateApiSurfaceTask = target.tasks.create("generateApiSurface") {
+            group = "datadog"
+            description = "Generate the API surface for all eligible source sets"
+        }
+
+        val commonCheckApiSurfaceChangesTask = target.tasks.create("checkApiSurfaceChanges") {
+            group = "datadog"
+            description = "Check the API surface changes for all eligible source sets"
+        }
+
+        target.kotlinExtension.sourceSets.all {
+            val sourceSetName = name
+            if (sourceSetName.contains("test", ignoreCase = true) ||
+                !sourceSetName.contains("main", ignoreCase = true)
+            ) {
+                return@all
+            }
+
+            val sourceFiles = kotlin.sourceDirectories
+            // no generated files yet, but let's keep it for the future, we will probably need to generate models
+            // for the mappers
+            val generatedFiles =
+                target.files(File(target.layout.buildDirectory.dir("generated").get().asFile, "json2kotlin"))
+            val apiDir = File(File(target.projectDir, "api"), name)
+            val surfaceFile = File(apiDir, FILE_NAME)
+            val generateApiSurfaceTaskName = createGenerateApiSurfaceTaskName(sourceSetName)
+            val checkApiSurfaceTaskName = createCheckApiSurfaceChangesTaskName(sourceSetName)
+
+            val generateApiSurfaceTask = target.tasks
+                .register(generateApiSurfaceTaskName, GenerateApiSurfaceTask::class.java) {
+                    this.sourceFiles = sourceFiles
+                    this.generatedFiles = generatedFiles
+                    this.surfaceFile = surfaceFile
+                    this.description = "Generate the API surface of the $sourceSetName source set"
+                    commonGenerateApiSurfaceTask.dependsOn(this)
+                }
+            target.tasks
+                .register(checkApiSurfaceTaskName, CheckApiSurfaceTask::class.java) {
+                    this.sourceSetName = sourceSetName
+                    this.description = "Check the API surface of the $sourceSetName source set"
+                    this.surfaceFile = surfaceFile
+                    dependsOn(generateApiSurfaceTask)
+                    commonCheckApiSurfaceChangesTask.dependsOn(this)
+                }
+
+            target.taskConfig<KotlinCompile> {
+                finalizedBy(generateApiSurfaceTask)
+            }
+        }
+    }
+
+    companion object {
+        const val FILE_NAME = "apiSurface"
+
+        internal fun createGenerateApiSurfaceTaskName(sourceSetName: String) =
+            "generate${sourceSetName.capitalize()}ApiSurface"
+
+        private fun createCheckApiSurfaceChangesTaskName(sourceSetName: String) =
+            "check${sourceSetName.capitalize()}ApiSurfaceChanges"
+    }
+}

--- a/tools/build-config/src/main/kotlin/com/datadog/build/plugin/apisurface/CheckApiSurfaceTask.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/build/plugin/apisurface/CheckApiSurfaceTask.kt
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.build.plugin.apisurface
+
+import com.datadog.build.utils.execShell
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class CheckApiSurfaceTask : DefaultTask() {
+
+    @Input
+    lateinit var sourceSetName: String
+
+    @InputFile
+    lateinit var surfaceFile: File
+
+    init {
+        group = "datadog"
+    }
+
+    // region Task
+
+    @TaskAction
+    fun applyTask() {
+        val lines = project.execShell(
+            "git",
+            "diff",
+            "--color=never",
+            "HEAD",
+            "--",
+            surfaceFile.absolutePath
+        )
+
+        val additions = lines.filter { it.matches(Regex("^\\+[^+].*$")) }
+        val removals = lines.filter { it.matches(Regex("^-[^-].*$")) }
+
+        if (additions.isNotEmpty() || removals.isNotEmpty()) {
+            error(
+                "Make sure you run the ${ApiSurfacePlugin.createGenerateApiSurfaceTaskName(sourceSetName)} task" +
+                    " before you push your PR.\n" +
+                    additions.joinToString("\n") + removals.joinToString("\n")
+            )
+        }
+    }
+
+    // endregion
+}

--- a/tools/build-config/src/main/kotlin/com/datadog/build/plugin/apisurface/GenerateApiSurfaceTask.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/build/plugin/apisurface/GenerateApiSurfaceTask.kt
@@ -1,0 +1,95 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.build.plugin.apisurface
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class GenerateApiSurfaceTask : DefaultTask() {
+
+    @get:InputFiles
+    lateinit var sourceFiles: FileCollection
+
+    @get:InputFiles
+    lateinit var generatedFiles: FileCollection
+
+    @get: OutputFile
+    lateinit var surfaceFile: File
+
+    private lateinit var visitor: KotlinFileVisitor
+
+    init {
+        group = "datadog"
+    }
+
+    // region Task
+
+    @TaskAction
+    fun applyTask() {
+        visitor = KotlinFileVisitor()
+        visitFileCollectionRecursively(sourceFiles)
+        visitFileCollectionRecursively(generatedFiles)
+
+        val apiSurface = visitor.description.toString()
+        if (apiSurface.isNotEmpty()) {
+            surfaceFile.printWriter().use {
+                it.print(apiSurface)
+            }
+        } else {
+            if (surfaceFile.parentFile.exists()) {
+                surfaceFile.parentFile.deleteRecursively()
+            }
+        }
+    }
+
+    // endregion
+
+    private fun visitDirectoryRecursively(file: File) {
+        when {
+            !file.exists() -> logger.info("File $file doesn't exist, ignoring")
+            file.isDirectory ->
+                file.listFiles().orEmpty()
+                    .sortedBy { it.absolutePath }
+                    .forEach { visitDirectoryRecursively(it) }
+            file.isFile -> visitFile(file)
+            else -> logger.error("${file.path} is neither file nor directory")
+        }
+    }
+
+    private fun visitFileCollectionRecursively(fileCollection: FileCollection) {
+        for (file in fileCollection.files) {
+            when {
+                !file.exists() -> logger.info("File $file doesn't exist, ignoring")
+                file.isDirectory ->
+                    file.listFiles().orEmpty()
+                        .sortedBy { it.absolutePath }
+                        .forEach { visitDirectoryRecursively(it) }
+
+                file.isFile -> visitFile(file)
+                else -> logger.error("${file.path} is neither file nor directory")
+            }
+        }
+    }
+
+    private fun visitFile(file: File) {
+        if (file.canRead()) {
+            if (file.extension == EXT_KT) {
+                visitor.visitFile(file)
+            }
+        } else {
+            logger.error("${file.path} is not readable")
+        }
+    }
+
+    private companion object {
+        const val EXT_KT = "kt"
+    }
+}

--- a/tools/build-config/src/main/kotlin/com/datadog/build/plugin/apisurface/KotlinFileVisitor.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/build/plugin/apisurface/KotlinFileVisitor.kt
@@ -1,0 +1,549 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.build.plugin.apisurface
+
+import kotlinx.ast.common.AstSource
+import kotlinx.ast.common.ast.Ast
+import kotlinx.ast.common.ast.AstNode
+import kotlinx.ast.common.ast.AstTerminal
+import kotlinx.ast.common.print
+import kotlinx.ast.grammar.kotlin.target.antlr.kotlin.KotlinGrammarAntlrKotlinParser
+import java.io.File
+
+class KotlinFileVisitor {
+
+    val description = StringBuilder()
+    private lateinit var pkg: String
+    private val imports = mutableMapOf<String, String>()
+
+    // region KotlinFileVisitor
+
+    @Suppress("TooGenericExceptionCaught")
+    fun visitFile(file: File, printAst: Boolean = false) {
+        val code = file.readText()
+        val source = AstSource.String(description = "Content of file ${file.path}", content = code)
+        val ast = KotlinGrammarAntlrKotlinParser.parseKotlinFile(source)
+
+        if (printAst) ast.print()
+        imports.clear()
+        try {
+            visitAst(ast, level = 0)
+        } catch (e: Exception) {
+            throw IllegalStateException("Error generating API surface for $file", e)
+        }
+    }
+
+    // endregion
+
+    // region Internal/Visitor
+
+    private fun visitAst(ast: Ast, level: Int) {
+        when (ast) {
+            is AstNode -> visitAstNode(ast, level)
+            is AstTerminal -> ignoreNode()
+            else -> error("Unable to handle $ast")
+        }
+    }
+
+    private fun visitAstNode(node: AstNode, level: Int) {
+        when (node.description) {
+            "kotlinFile",
+            "importList",
+            "topLevelObject",
+            "declaration",
+            "classMemberDeclarations",
+            "classMemberDeclaration",
+            "enumEntries",
+            "kamoulox" -> node.children.forEach {
+                visitAst(it, level)
+            }
+            "packageHeader" -> visitPackage(node)
+            "importHeader" -> visitImport(node)
+            "classDeclaration" -> visitTypeDeclaration(node, level, "class")
+            "objectDeclaration" -> visitTypeDeclaration(node, level, "object")
+            "companionObject" -> visitTypeDeclaration(node, level, "companion object")
+            "secondaryConstructor" -> visitSecondaryConstructor(node, level)
+            "functionDeclaration" -> visitFunctionDeclaration(node, level)
+            "propertyDeclaration" -> visitProperty(node, level)
+            "typeAlias" -> visitTypeAlias(node, level)
+            "enumEntry" -> visitEnumEntry(node, level)
+            "semis" -> ignoreNode()
+            else -> println("??? ${node.description}")
+        }
+    }
+
+    private fun visitTypeDeclaration(node: AstNode, level: Int, type: String) {
+        if (node.isInternal() || node.isPrivate()) return
+
+        description.append(INDENT.repeat(level))
+
+        // Modifiers
+        if (node.isDeprecated()) description.append("DEPRECATED ")
+        if (node.isDataClass()) description.append("data ")
+        if (node.isSealed()) description.append("sealed ")
+        if (node.isProtected()) description.append("protected ")
+        if (node.isOpen()) description.append("open ")
+        if (node.isAbstract()) description.append("abstract ")
+
+        when {
+            node.hasChildTerminal("INTERFACE") -> description.append("interface ")
+            node.isEnum() -> description.append("enum ")
+            node.isAnnotation() -> description.append("annotation ")
+            else -> description.append("$type ")
+        }
+
+        // Canonical name
+        if (level == 0) description.append(pkg)
+        description.append(node.identifierName())
+
+        // Generics
+        visitTypeParameters(node)
+
+        // Parent types
+        visitParentTypes(node)
+
+        // EOL
+        description.append("\n")
+
+        // Primary constructor
+        val primaryConstructor = node.firstChildNodeOrNull("primaryConstructor")
+        if (primaryConstructor != null) {
+            visitPrimaryConstructor(primaryConstructor, level + 1)
+        }
+
+        // Content
+        node.firstChildNodeOrNull("classBody")?.children?.forEach {
+            visitAst(it, level + 1)
+        }
+        node.firstChildNodeOrNull("enumClassBody")?.children?.forEach {
+            visitAst(it, level + 1)
+        }
+    }
+
+    private fun visitPrimaryConstructor(node: AstNode, level: Int) {
+        if (node.isInternal() || node.isPrivate()) return
+
+        description.append(INDENT.repeat(level))
+
+        description.append("constructor")
+
+        // Parameters
+        visitConstructorParameters(node)
+
+        // EOL
+        description.append("\n")
+    }
+
+    private fun visitSecondaryConstructor(node: AstNode, level: Int) {
+        if (node.isInternal() || node.isPrivate()) return
+
+        description.append(INDENT.repeat(level))
+
+        // Modifiers
+        if (node.isDeprecated()) description.append("DEPRECATED ")
+        if (node.isProtected()) description.append("protected ")
+
+        description.append("constructor")
+
+        // Parameters
+        visitFunctionParameters(node)
+
+        // EOL
+        description.append("\n")
+    }
+
+    private fun visitFunctionDeclaration(node: AstNode, level: Int) {
+        if (node.isInternal() || node.isPrivate()) return
+
+        description.append(INDENT.repeat(level))
+
+        // Modifiers
+        if (node.isDeprecated()) description.append("DEPRECATED ")
+        if (node.isOverride()) description.append("override ")
+        if (node.isProtected()) description.append("protected ")
+        if (node.isOpen()) description.append("open ")
+        if (node.isAbstract()) description.append("abstract ")
+
+        description.append("fun ")
+
+        // Generics
+        visitTypeParameters(node)
+        if (node.hasChildNode("typeParameters")) {
+            description.append(" ")
+        }
+
+        visitReceiver(node)
+        if (node.hasChildNode("receiverType")) {
+            description.append(".")
+        }
+
+        // Name
+        description.append(node.identifierName())
+
+        // Parameters
+        visitFunctionParameters(node)
+
+        // Return type
+        val type = node.firstChildNodeOrNull("type")
+        type?.let {
+            description.append(": ")
+            description.append(it.typeName())
+        }
+
+        // EOL
+        description.append("\n")
+    }
+
+    private fun visitProperty(node: AstNode, level: Int) {
+        if (node.isInternal() || node.isPrivate()) return
+
+        description.append(INDENT.repeat(level))
+
+        // Modifiers
+        if (node.isDeprecated()) description.append("DEPRECATED ")
+        if (node.isOverride()) description.append("override ")
+        if (node.isProtected()) description.append("protected ")
+        if (node.isOpen()) description.append("open ")
+        if (node.isAbstract()) description.append("abstract ")
+        if (node.isConst()) description.append("const ")
+
+        // Property type
+        if (node.hasChildTerminal("VAL")) {
+            description.append("val ")
+        } else if (node.hasChildTerminal("VAR")) {
+            description.append("var ")
+        }
+
+        val variableDeclaration = node.firstChildNode("variableDeclaration")
+        description.append(variableDeclaration.identifierName())
+
+        // Type
+        description.append(": ")
+        val propertyType = variableDeclaration.firstChildNodeOrNull("type")
+        checkNotNull(propertyType) {
+            "Public properties should use an explicit type. " +
+                "Error on property ${variableDeclaration.identifierName()}"
+        }
+        description.append(propertyType.typeName())
+
+        // EOL
+        description.append("\n")
+    }
+
+    private fun visitEnumEntry(node: AstNode, level: Int) {
+        description.append(INDENT.repeat(level))
+        description.append("- ")
+        description.append(node.identifierName())
+        description.append("\n")
+    }
+
+    private fun visitParentTypes(node: AstNode) {
+        val parentSpecifiers = node.firstChildNodeOrNull("delegationSpecifiers")
+            ?.childrenNodes("annotatedDelegationSpecifier")
+            ?.map {
+                val delegation = it.firstChildNode("delegationSpecifier")
+                val typeRef = delegation.firstChildNodeOrNull("constructorInvocation")
+                    ?: delegation.firstChildNodeOrNull("explicitDelegation")
+                    ?: delegation
+                typeRef.typeReferenceName()
+            }
+        if (!parentSpecifiers.isNullOrEmpty()) {
+            description.append(" : ")
+            description.append(parentSpecifiers.joinToString(", "))
+        }
+    }
+
+    private fun visitTypeParameters(node: AstNode) {
+        val typeParameters = node.firstChildNodeOrNull("typeParameters") ?: return
+        val generics = typeParameters.childrenNodes("typeParameter")
+            .map {
+                val name = it.identifierName()
+                val type = it.firstChildNodeOrNull("type")?.typeName()
+                name + (if (type == null) "" else ": $type")
+            }
+        description.append(
+            generics.joinToString(", ", prefix = "<", postfix = ">")
+        )
+    }
+
+    private fun visitReceiver(node: AstNode) {
+        val receiverType = node.firstChildNodeOrNull("receiverType") ?: return
+        description.append(receiverType.typeName())
+    }
+
+    private fun visitFunctionParameters(node: AstNode) {
+        description.append("(")
+        description.append(
+            node.firstChildNode("functionValueParameters")
+                .childrenNodes("functionValueParameter")
+                .joinToString(", ") { it.parameterType() }
+        )
+        description.append(")")
+    }
+
+    private fun visitConstructorParameters(node: AstNode) {
+        description.append("(")
+        description.append(
+            node.firstChildNode("classParameters")
+                .childrenNodes("classParameter")
+                .joinToString(", ") { it.constructorParameterType() }
+        )
+        description.append(")")
+    }
+
+    private fun visitPackage(node: AstNode) {
+        val identifier = node.firstChildNodeOrNull("identifier")
+        pkg = if (identifier != null) {
+            identifier.identifierName() + "."
+        } else {
+            ""
+        }
+    }
+
+    private fun visitImport(node: AstNode) {
+        val import = node.firstChildNode("identifier").identifierName()
+
+        val importAlias = node.firstChildNodeOrNull("importAlias")?.identifierName()
+
+        imports[importAlias ?: import.substringAfterLast(".")] = import
+    }
+
+    private fun visitTypeAlias(node: AstNode, level: Int) {
+        if (node.isInternal() || node.isPrivate()) return
+
+        val name = node.identifierName()
+
+        val type = node.firstChildNode("type")
+
+        description.append(INDENT.repeat(level))
+        val rootTypeName = if (type.hasChildNode("functionType")) {
+            type.lambdaName()
+        } else {
+            type.typeName()
+        }
+        description.append("typealias $name = $rootTypeName\n")
+    }
+
+    private fun ignoreNode() {
+        // Do Nothing
+    }
+
+    // endregion
+
+    // region Internal/Ext/Modifiers
+
+    private fun AstNode.isSealed(): Boolean {
+        return hasModifier("classModifier", "SEALED")
+    }
+
+    private fun AstNode.isDataClass(): Boolean {
+        return hasModifier("classModifier", "DATA")
+    }
+
+    private fun AstNode.isEnum(): Boolean {
+        return hasModifier("classModifier", "ENUM")
+    }
+
+    private fun AstNode.isAnnotation(): Boolean {
+        return hasModifier("classModifier", "ANNOTATION")
+    }
+
+    private fun AstNode.isProtected(): Boolean {
+        return hasModifier("visibilityModifier", "PROTECTED")
+    }
+
+    private fun AstNode.isPrivate(): Boolean {
+        return hasModifier("visibilityModifier", "PRIVATE")
+    }
+
+    private fun AstNode.isInternal(): Boolean {
+        return hasModifier("visibilityModifier", "INTERNAL")
+    }
+
+    private fun AstNode.isOpen(): Boolean {
+        return hasModifier("inheritanceModifier", "OPEN")
+    }
+
+    private fun AstNode.isAbstract(): Boolean {
+        return hasModifier("inheritanceModifier", "ABSTRACT")
+    }
+
+    private fun AstNode.isOverride(): Boolean {
+        return hasModifier("memberModifier", "OVERRIDE")
+    }
+
+    private fun AstNode.isConst(): Boolean {
+        return hasModifier("propertyModifier", "CONST")
+    }
+
+    private fun AstNode.hasModifier(group: String, modifier: String): Boolean {
+        val modifiers = firstChildNodeOrNull("modifiers") ?: return false
+        return modifiers.childrenNodes("modifier")
+            .mapNotNull { it.firstChildNodeOrNull(group) }
+            .any { it.firstChildTerminalOrNull(modifier) != null }
+    }
+
+    private fun AstNode.isDeprecated(): Boolean {
+        val modifiers = firstChildNodeOrNull("modifiers") ?: return false
+        return modifiers.childrenNodes("annotation")
+            .mapNotNull { it.firstChildNodeOrNull("singleAnnotation") }
+            .mapNotNull { it.firstChildNodeOrNull("unescapedAnnotation") }
+            .map { it.firstChildNodeOrNull("constructorInvocation") ?: it }
+            .filter { it.hasChildNode("userType") }
+            .any { it.typeReferenceName() in DEPRECATED_ANNOTATIONS }
+    }
+
+    // endregion
+
+    // region Internal/Ext/Node
+
+    private fun Ast.isNode(description: String): Boolean {
+        return this is AstNode && this.description == description
+    }
+
+    private fun AstNode.firstChildNode(description: String): AstNode {
+        val first = firstChildNodeOrNull(description)
+        checkNotNull(first) { "Unable to find a child with description $description in \n$this" }
+        return first
+    }
+
+    private fun AstNode.firstChildNodeOrNull(description: String): AstNode? {
+        return children.firstOrNull { it.isNode(description) } as? AstNode
+    }
+
+    private fun AstNode.hasChildNode(description: String): Boolean {
+        return children.any { it.isNode(description) }
+    }
+
+    private fun AstNode.childrenNodes(description: String): List<AstNode> {
+        return children.filterIsInstance<AstNode>()
+            .filter { it.description == description }
+    }
+
+    // endregion
+
+    // region Internal/Ext/Terminal
+
+    private fun Ast.isTerminal(description: String): Boolean {
+        return this is AstTerminal && this.description == description
+    }
+
+    private fun AstNode.firstChildTerminalOrNull(description: String): AstTerminal? {
+        return children.firstOrNull { it.isTerminal(description) } as? AstTerminal
+    }
+
+    private fun AstNode.hasChildTerminal(description: String): Boolean {
+        return children.any { it.isTerminal(description) }
+    }
+
+    // endregion
+
+    // region Internal/Ext/Names
+
+    private fun AstNode.identifierName(): String {
+        return childrenNodes("simpleIdentifier")
+            .joinToString(".") {
+                it.firstChildTerminalOrNull("Identifier")?.text ?: it.children.first()
+                    .expressionValue()
+            }
+    }
+
+    private fun AstNode.typeName(): String {
+        val nullableType = firstChildNodeOrNull("nullableType")
+        return when {
+            nullableType != null -> nullableType.typeName() + "?"
+            hasChildNode("functionType") -> lambdaName()
+            else -> firstChildNode("typeReference").typeReferenceName()
+        }
+    }
+
+    private fun AstNode.typeReferenceName(): String {
+        val simpleUserTypes = firstChildNode("userType")
+            .childrenNodes("simpleUserType")
+
+        return simpleUserTypes.fold("") { aggr, userType ->
+            val typeName = userType.identifierName()
+            val generics = userType.firstChildNodeOrNull("typeArguments")
+                ?.childrenNodes("typeProjection")
+                ?.joinToString(", ", prefix = "<", postfix = ">") {
+                    it.firstChildNodeOrNull("type")?.typeName()
+                        ?: it.firstChildTerminalOrNull("MULT")?.text.toString()
+                } ?: ""
+            if (aggr.isEmpty()) {
+                (imports[typeName] ?: typeName) + generics
+            } else {
+                "$aggr.$typeName$generics"
+            }
+        }
+    }
+
+    private fun AstNode.lambdaName(): String {
+        val functionType = firstChildNode("functionType")
+
+        val receiver = functionType.firstChildNodeOrNull("receiverType")?.typeName()
+        val functionTypeParamsNode = functionType.firstChildNode("functionTypeParameters")
+        val params =
+            (functionTypeParamsNode.firstChildNodeOrNull("parameter") ?: functionTypeParamsNode)
+                .childrenNodes("type")
+                .joinToString(", ") { it.typeName() }
+        val returns = functionType.firstChildNode("type").typeName()
+
+        return if (receiver == null) {
+            "($params) -> $returns"
+        } else {
+            "$receiver.($params) -> $returns"
+        }
+    }
+
+    private fun AstNode.parameterType(): String {
+        val typeName = firstChildNode("parameter")
+            .firstChildNode("type")
+            .typeName()
+
+        return if (hasChildNode("expression")) {
+            val defaultValue = firstChildNode("expression").expressionValue()
+            "$typeName = $defaultValue"
+        } else {
+            typeName
+        }
+    }
+
+    private fun AstNode.constructorParameterType(): String {
+        val typeName = firstChildNode("type")
+            .typeName()
+
+        return if (hasChildNode("expression")) {
+            val defaultValue = firstChildNode("expression").expressionValue()
+            "$typeName = $defaultValue"
+        } else {
+            typeName
+        }
+    }
+
+    private fun Ast.expressionValue(): String {
+        return if (this is AstNode) {
+            children.map { it.expressionValue() }.joinToString("")
+        } else if (this is AstTerminal) {
+            text
+        } else {
+            println("EXPR ?? $this")
+            "…"
+        }
+    }
+
+    // endregion
+
+    companion object {
+        private const val INDENT = "  "
+
+        private val DEPRECATED_ANNOTATIONS = arrayOf(
+            "java.lang.Deprecated",
+            "kotlin.Deprecated",
+            "Deprecated"
+        )
+    }
+}

--- a/tools/build-config/src/main/kotlin/com/datadog/build/plugin/config/DatadogBuildConfigExtension.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/build/plugin/config/DatadogBuildConfigExtension.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.build
+package com.datadog.build.plugin.config
 
 import org.gradle.api.provider.Property
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget

--- a/tools/build-config/src/main/kotlin/com/datadog/build/plugin/config/DatadogProjectConfigurationPlugin.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/build/plugin/config/DatadogProjectConfigurationPlugin.kt
@@ -4,15 +4,16 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.build
+package com.datadog.build.plugin.config
 
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import com.datadog.build.AndroidConfig
+import com.datadog.build.utils.taskConfig
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -204,14 +205,6 @@ private fun CommonExtension<*, *, *, *, *, *>.packagingConfigure() {
 }
 
 // endregion
-
-inline fun <reified T : Task> Project.taskConfig(
-    crossinline configure: T.() -> Unit
-) {
-    afterEvaluate {
-        tasks.withType(T::class.java) { configure() }
-    }
-}
 
 private fun JvmTarget.toJavaVersion(): JavaVersion {
     // list only LTS releases

--- a/tools/build-config/src/main/kotlin/com/datadog/build/utils/GradleUtils.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/build/utils/GradleUtils.kt
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.build.utils
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStreamReader
+
+inline fun <reified T : Task> Project.taskConfig(
+    crossinline configure: T.() -> Unit
+) {
+    afterEvaluate {
+        tasks.withType(T::class.java) { configure() }
+    }
+}
+
+fun Project.execShell(vararg command: String): List<String> {
+    val outputStream = ByteArrayOutputStream()
+    this.exec {
+        commandLine(*command)
+        standardOutput = outputStream
+    }
+
+    val reader = InputStreamReader(ByteArrayInputStream(outputStream.toByteArray()))
+    return reader.readLines()
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds a capability to generate public API surface. Generator code was taken from Android SDK repo and modified to support multiple source sets.

Generator doesn't support `expect/actual` thing, so if there is such method/class, it will be duplicated between surface files, but this is not a problem.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

