### PR TITLE
RUM-4821: Implement `Rum` and `RumConfiguration` classes

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -10,9 +10,14 @@ import,androidx.compose.material3,Apache-2.0,Copyright 2018 The Android Open Sou
 import,androidx.compose.runtime,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.compose.ui,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.core,Apache-2.0,Copyright 2018 The Android Open Source Project
+import,androidx.customview,Apache-2.0,Copyright 2018 The Android Open Source Project
+import,androidx.fragment,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.lifecycle,Apache-2.0,Copyright 2018 The Android Open Source Project
+import,androidx.loader,Apache-2.0,Copyright 2018 The Android Open Source Project
+import,androidx.navigation,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.savedstate,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.versionedparcelable,Apache-2.0,Copyright 2018 The Android Open Source Project
+import,androidx.viewpager,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,com.datadoghq,Apache-2.0,Copyright 2019-Present Datadog, Inc.
 import,org.jetbrains,Apache-2.0,Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,org.jetbrains.kotlin,Apache-2.0,Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors

--- a/dd-sdk-kotlin-multiplatform-core/android-transitiveDependencies
+++ b/dd-sdk-kotlin-multiplatform-core/android-transitiveDependencies
@@ -1,6 +1,6 @@
 Dependencies List
 
-com.datadoghq:dd-sdk-android-core:2.8.0                         :  671 Kb
+com.datadoghq:dd-sdk-android-core:2.10.1                        :  682 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 

--- a/dd-sdk-kotlin-multiplatform-core/build.gradle.kts
+++ b/dd-sdk-kotlin-multiplatform-core/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.datadog.build.AndroidConfig
-import org.jetbrains.kotlin.gradle.targets.native.tasks.PodGenTask
 
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
@@ -46,10 +45,6 @@ kotlin {
             )
             version = libs.versions.datadog.ios.get()
         }
-
-        // XCode 15 requires IPHONEOS_DEPLOYMENT_TARGET = 12 at least
-        // filed https://youtrack.jetbrains.com/issue/KT-67757
-        applyXCode15BuildWorkaroundForDatadogPods()
     }
 
     sourceSets {
@@ -61,29 +56,6 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
-        }
-    }
-}
-
-fun applyXCode15BuildWorkaroundForDatadogPods() {
-    tasks.withType<PodGenTask>().configureEach {
-        doLast {
-            val file = project.layout.buildDirectory
-                .file("cocoapods/synthetic/ios/Podfile")
-                .get()
-                .asFile
-            val lines = file.readLines()
-            val output = file.bufferedWriter()
-
-            output.use {
-                for (line in lines) {
-                    output.write(
-                        line.replace(" 11 ", " 12 ")
-                            .replace("{11}", "{12}")
-                    )
-                    output.write(("\n"))
-                }
-            }
         }
     }
 }

--- a/features/dd-sdk-kotlin-multiplatform-logs/android-transitiveDependencies
+++ b/features/dd-sdk-kotlin-multiplatform-logs/android-transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
-com.datadoghq:dd-sdk-android-core:2.8.0                         :  671 Kb
-com.datadoghq:dd-sdk-android-logs:2.8.0                         :  133 Kb
+com.datadoghq:dd-sdk-android-core:2.10.1                        :  682 Kb
+com.datadoghq:dd-sdk-android-logs:2.10.1                        :  133 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 

--- a/features/dd-sdk-kotlin-multiplatform-rum/android-transitiveDependencies
+++ b/features/dd-sdk-kotlin-multiplatform-rum/android-transitiveDependencies
@@ -1,9 +1,33 @@
 Dependencies List
 
-com.datadoghq:dd-sdk-android-core:2.8.0                         :  671 Kb
-com.datadoghq:dd-sdk-android-rum:2.8.0                          : 1536 Kb
+androidx.activity:activity:1.5.1                                :   90 Kb
+androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
+androidx.annotation:annotation:1.2.0                            :   28 Kb
+androidx.arch.core:core-common:2.1.0                            :   10 Kb
+androidx.arch.core:core-runtime:2.0.0                           :    5 Kb
+androidx.collection:collection:1.1.0                            :   41 Kb
+androidx.core:core-ktx:1.2.0                                    :  155 Kb
+androidx.core:core:1.8.0                                        : 1052 Kb
+androidx.customview:customview:1.0.0                            :   32 Kb
+androidx.fragment:fragment:1.5.1                                :  328 Kb
+androidx.lifecycle:lifecycle-common:2.5.1                       :   23 Kb
+androidx.lifecycle:lifecycle-livedata-core:2.5.1                :    9 Kb
+androidx.lifecycle:lifecycle-livedata:2.0.0                     :    9 Kb
+androidx.lifecycle:lifecycle-runtime:2.5.1                      :   12 Kb
+androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.1         :   34 Kb
+androidx.lifecycle:lifecycle-viewmodel:2.5.1                    :   34 Kb
+androidx.loader:loader:1.0.0                                    :   32 Kb
+androidx.navigation:navigation-common:2.3.0                     :   54 Kb
+androidx.navigation:navigation-runtime:2.3.0                    :   46 Kb
+androidx.savedstate:savedstate:1.2.0                            :   18 Kb
+androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
+androidx.viewpager:viewpager:1.0.0                              :   52 Kb
+com.datadoghq:dd-sdk-android-core:2.10.1                        :  682 Kb
+com.datadoghq:dd-sdk-android-rum:2.10.1                         : 1580 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1          :   19 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.1         : 1457 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    3 Mb
+Total transitive dependencies size                              :    7 Mb
 

--- a/features/dd-sdk-kotlin-multiplatform-rum/api/androidMain/apiSurface
+++ b/features/dd-sdk-kotlin-multiplatform-rum/api/androidMain/apiSurface
@@ -1,0 +1,43 @@
+object com.datadog.kmp.rum.Rum
+  fun enable(com.datadog.kmp.rum.configuration.RumConfiguration)
+fun RumConfiguration.Builder.trackNonFatalAnrs(Boolean): RumConfiguration.Builder
+fun RumConfiguration.Builder.useViewTrackingStrategy(com.datadog.kmp.rum.tracking.ViewTrackingStrategy?): RumConfiguration.Builder
+fun RumConfiguration.Builder.trackUserInteractions(Array<com.datadog.kmp.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.kmp.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): RumConfiguration.Builder
+class com.datadog.kmp.rum.tracking.AcceptAllActivities : ComponentPredicate<android.app.Activity>
+  override fun accept(android.app.Activity): Boolean
+  override fun getViewName(android.app.Activity): String?
+class com.datadog.kmp.rum.tracking.AcceptAllDefaultFragments : ComponentPredicate<android.app.Fragment>
+  override fun accept(android.app.Fragment): Boolean
+  override fun getViewName(android.app.Fragment): String?
+class com.datadog.kmp.rum.tracking.AcceptAllNavDestinations : ComponentPredicate<androidx.navigation.NavDestination>
+  override fun accept(androidx.navigation.NavDestination): Boolean
+  override fun getViewName(androidx.navigation.NavDestination): String?
+class com.datadog.kmp.rum.tracking.AcceptAllSupportFragments : ComponentPredicate<androidx.fragment.app.Fragment>
+  override fun accept(androidx.fragment.app.Fragment): Boolean
+  override fun getViewName(androidx.fragment.app.Fragment): String?
+class com.datadog.kmp.rum.tracking.ActivityViewTrackingStrategy : ViewTrackingStrategy
+  constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
+  override fun register(android.content.Context)
+  override fun unregister(android.content.Context?)
+interface com.datadog.kmp.rum.tracking.ComponentPredicate<T>
+  fun accept(T): Boolean
+  fun getViewName(T): String?
+class com.datadog.kmp.rum.tracking.FragmentViewTrackingStrategy : ViewTrackingStrategy
+  constructor(Boolean, ComponentPredicate<androidx.fragment.app.Fragment> = AcceptAllSupportFragments(), ComponentPredicate<android.app.Fragment> = AcceptAllDefaultFragments())
+  override fun register(android.content.Context)
+  override fun unregister(android.content.Context?)
+interface com.datadog.kmp.rum.tracking.InteractionPredicate
+  fun getTargetName(Any): String?
+class com.datadog.kmp.rum.tracking.MixedViewTrackingStrategy : ViewTrackingStrategy
+  constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities(), ComponentPredicate<androidx.fragment.app.Fragment> = AcceptAllSupportFragments(), ComponentPredicate<android.app.Fragment> = AcceptAllDefaultFragments())
+  override fun register(android.content.Context)
+  override fun unregister(android.content.Context?)
+class com.datadog.kmp.rum.tracking.NavigationViewTrackingStrategy : ViewTrackingStrategy
+  constructor(Int, Boolean, ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())
+  override fun register(android.content.Context)
+  override fun unregister(android.content.Context?)
+interface com.datadog.kmp.rum.tracking.ViewAttributesProvider
+  fun extractAttributes(android.view.View, MutableMap<String, Any?>)
+interface com.datadog.kmp.rum.tracking.ViewTrackingStrategy
+  fun register(android.content.Context)
+  fun unregister(android.content.Context?)

--- a/features/dd-sdk-kotlin-multiplatform-rum/api/commonMain/apiSurface
+++ b/features/dd-sdk-kotlin-multiplatform-rum/api/commonMain/apiSurface
@@ -1,0 +1,20 @@
+object com.datadog.kmp.rum.Rum
+  fun enable(com.datadog.kmp.rum.configuration.RumConfiguration)
+class com.datadog.kmp.rum.configuration.RumConfiguration
+  class Builder
+    constructor(String)
+    fun setSessionSampleRate(Float): Builder
+    fun setTelemetrySampleRate(Float): Builder
+    fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
+    fun trackBackgroundEvents(Boolean): Builder
+    fun trackFrustrations(Boolean): Builder
+    fun setVitalsUpdateFrequency(VitalsUpdateFrequency): Builder
+    fun setSessionListener(RumSessionListener): Builder
+    fun build(): RumConfiguration
+interface com.datadog.kmp.rum.configuration.RumSessionListener
+  fun onSessionStarted(String, Boolean)
+enum com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
+  - FREQUENT
+  - AVERAGE
+  - RARE
+  - NEVER

--- a/features/dd-sdk-kotlin-multiplatform-rum/api/iosMain/apiSurface
+++ b/features/dd-sdk-kotlin-multiplatform-rum/api/iosMain/apiSurface
@@ -1,0 +1,16 @@
+object com.datadog.kmp.rum.Rum
+  fun enable(com.datadog.kmp.rum.configuration.RumConfiguration)
+fun RumConfiguration.Builder.trackUiKitViews(com.datadog.kmp.rum.tracking.UIKitRUMViewsPredicate = DefaultUIKitRUMViewsPredicate()): RumConfiguration.Builder
+fun RumConfiguration.Builder.trackUiKitActions(com.datadog.kmp.rum.tracking.UIKitRUMActionsPredicate = DefaultUIKitRUMActionsPredicate()): RumConfiguration.Builder
+class com.datadog.kmp.rum.tracking.DefaultUIKitRUMActionsPredicate : UIKitRUMActionsPredicate
+  override fun createAction(platform.UIKit.UIView): RumAction?
+class com.datadog.kmp.rum.tracking.DefaultUIKitRUMViewsPredicate : UIKitRUMViewsPredicate
+  override fun createView(platform.UIKit.UIViewController): RumView?
+data class com.datadog.kmp.rum.tracking.RumAction
+  constructor(String, Map<String, Any?>)
+data class com.datadog.kmp.rum.tracking.RumView
+  constructor(String, Map<String, Any?>)
+interface com.datadog.kmp.rum.tracking.UIKitRUMActionsPredicate
+  fun createAction(platform.UIKit.UIView): RumAction?
+interface com.datadog.kmp.rum.tracking.UIKitRUMViewsPredicate
+  fun createView(platform.UIKit.UIViewController): RumView?

--- a/features/dd-sdk-kotlin-multiplatform-rum/build.gradle.kts
+++ b/features/dd-sdk-kotlin-multiplatform-rum/build.gradle.kts
@@ -5,6 +5,7 @@
  */
 
 import com.datadog.build.AndroidConfig
+import dev.mokkery.MockMode
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -14,6 +15,7 @@ plugins {
     alias(libs.plugins.dependencyLicense)
     id("api-surface")
     id("transitive-dependencies")
+    alias(libs.plugins.mokkery)
 }
 
 kotlin {
@@ -43,6 +45,8 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(libs.datadog.android.rum)
+            implementation(libs.androidx.fragment)
+            implementation(libs.androidx.navigation.runtime)
         }
         androidUnitTest.dependencies {
             implementation(libs.bundles.jUnit5)
@@ -56,8 +60,21 @@ kotlin {
             implementation(libs.kotlin.test)
         }
     }
+
+    configurations.androidMainImplementation {
+        // this is because we have to use FragmentX 1.5.1 (because 1.4.x ships Lint rules which are not
+        // compatible with AGP 8.4.+), and it brings these dependencies. We can strip them out, because since Kotlin
+        // 1.8 everything is in the main stdlib.
+        exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk7")
+        exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
+    }
 }
 
 android {
     namespace = "com.datadog.kmp.rum"
+}
+
+mokkery {
+    defaultMockMode = MockMode.autofill
+    ignoreFinalMembers = true
 }

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/Rum.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/Rum.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum
+
+import com.datadog.kmp.rum.configuration.RumConfiguration
+import com.datadog.android.rum.Rum as NativeRum
+import com.datadog.android.rum.RumConfiguration as NativeRumConfiguration
+
+/**
+ * An entry point to Datadog RUM feature.
+ */
+actual object Rum {
+    /**
+     * Enables a RUM feature based on the configuration provided and registers RUM monitor.
+     *
+     * @param rumConfiguration Configuration to use for the feature.
+     */
+    actual fun enable(rumConfiguration: RumConfiguration) {
+        NativeRum.enable(rumConfiguration.nativeConfiguration as NativeRumConfiguration)
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration
+
+import com.datadog.android.rum.RumMonitor
+import com.datadog.kmp.rum.configuration.internal.AndroidRumConfigurationBuilder
+import com.datadog.kmp.rum.configuration.internal.PlatformRumConfigurationBuilder
+import com.datadog.kmp.rum.tracking.InteractionPredicate
+import com.datadog.kmp.rum.tracking.ViewAttributesProvider
+import com.datadog.kmp.rum.tracking.ViewTrackingStrategy
+import com.datadog.kmp.rum.tracking.internal.NoOpInteractionPredicate
+
+/**
+ * Enable tracking of non-fatal ANRs. This is enabled by default on Android API 29 and
+ * below, and disabled by default on Android API 30 and above. Android API 30+ has a
+ * capability to report fatal ANRs (always enabled). Please note, that tracking non-fatal
+ * ANRs is using Watchdog thread approach, which can be noisy, and also leads to ANR
+ * duplication on Android 30+ if fatal ANR happened, because Watchdog thread approach cannot
+ * categorize ANR as fatal or non-fatal.
+ *
+ * @param enabled whether tracking of non-fatal ANRs is enabled or not.
+ */
+fun RumConfiguration.Builder.trackNonFatalAnrs(enabled: Boolean): RumConfiguration.Builder {
+    nativePlatformBuilder.trackNonFatalAnrs(enabled)
+    return this
+}
+
+/**
+ * Sets the automatic view tracking strategy used by the SDK.
+ * By default [com.datadog.kmp.rum.tracking.ActivityViewTrackingStrategy] will be used.
+ * @param strategy as the [ViewTrackingStrategy]
+ * Note: If `null` is passed, the RUM Monitor will let you handle View events manually.
+ * This means that you should call [RumMonitor.startView] and [RumMonitor.stopView]
+ * yourself. A view should be started when it becomes visible and interactive
+ * (equivalent to `onResume`) and be stopped when it's paused (equivalent to `onPause`).
+ * @see [com.datadog.kmp.rum.tracking.ActivityViewTrackingStrategy]
+ * @see [com.datadog.kmp.rum.tracking.FragmentViewTrackingStrategy]
+ * @see [com.datadog.kmp.rum.tracking.MixedViewTrackingStrategy]
+ * @see [com.datadog.kmp.rum.tracking.NavigationViewTrackingStrategy]
+ */
+fun RumConfiguration.Builder.useViewTrackingStrategy(strategy: ViewTrackingStrategy?): RumConfiguration.Builder {
+    nativePlatformBuilder.useViewTrackingStrategy(strategy)
+    return this
+}
+
+/**
+ * Enable the user interaction automatic tracker. By enabling this feature the SDK will intercept
+ * UI interaction events (e.g.: taps, scrolls, swipes) and automatically send those as RUM UserActions for you.
+ * @param touchTargetExtraAttributesProviders an array with your own implementation of the
+ * target attributes provider.
+ * @param interactionPredicate an interface to provide custom values for the
+ * actions events properties.
+ * @see [ViewAttributesProvider]
+ * @see [InteractionPredicate]
+ */
+fun RumConfiguration.Builder.trackUserInteractions(
+    touchTargetExtraAttributesProviders: Array<ViewAttributesProvider> = emptyArray(),
+    interactionPredicate: InteractionPredicate = NoOpInteractionPredicate()
+): RumConfiguration.Builder {
+    nativePlatformBuilder
+        .trackUserInteractions(touchTargetExtraAttributesProviders, interactionPredicate)
+    return this
+}
+
+internal actual fun platformConfigurationBuilder(applicationId: String): PlatformRumConfigurationBuilder<Any> =
+    AndroidRumConfigurationBuilder(applicationId)
+
+private val RumConfiguration.Builder.nativePlatformBuilder
+    get() = platformBuilder as AndroidRumConfigurationBuilder

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilder.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilder.kt
@@ -1,0 +1,127 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration.internal
+
+import android.content.Context
+import android.view.View
+import com.datadog.android.api.SdkCore
+import com.datadog.kmp.rum.configuration.RumSessionListener
+import com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
+import com.datadog.kmp.rum.tracking.InteractionPredicate
+import com.datadog.kmp.rum.tracking.ViewAttributesProvider
+import com.datadog.kmp.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.rum.RumConfiguration as NativeAndroidConfiguration
+import com.datadog.android.rum.RumSessionListener as NativeRumSessionListener
+import com.datadog.android.rum.configuration.VitalsUpdateFrequency as NativeVitalsUpdateFrequency
+import com.datadog.android.rum.tracking.InteractionPredicate as NativeInteractionPredicate
+import com.datadog.android.rum.tracking.ViewAttributesProvider as NativeViewAttributesProvider
+import com.datadog.android.rum.tracking.ViewTrackingStrategy as NativeViewTrackingStrategy
+
+internal class AndroidRumConfigurationBuilder : PlatformRumConfigurationBuilder<NativeAndroidConfiguration> {
+
+    private val nativeConfigurationBuilder: NativeAndroidConfiguration.Builder
+
+    constructor(applicationId: String) : this(NativeAndroidConfiguration.Builder(applicationId))
+
+    internal constructor(nativeConfigurationBuilder: NativeAndroidConfiguration.Builder) {
+        this.nativeConfigurationBuilder = nativeConfigurationBuilder
+    }
+
+    override fun setSessionSampleRate(sampleRate: Float) {
+        nativeConfigurationBuilder.setSessionSampleRate(sampleRate)
+    }
+
+    override fun setTelemetrySampleRate(sampleRate: Float) {
+        nativeConfigurationBuilder.setTelemetrySampleRate(sampleRate)
+    }
+
+    override fun trackLongTasks(longTaskThresholdMs: Long) {
+        nativeConfigurationBuilder.trackLongTasks(longTaskThresholdMs)
+    }
+
+    override fun trackBackgroundEvents(enabled: Boolean) {
+        nativeConfigurationBuilder.trackBackgroundEvents(enabled)
+    }
+
+    override fun trackFrustrations(enabled: Boolean) {
+        nativeConfigurationBuilder.trackFrustrations(enabled)
+    }
+
+    override fun setVitalsUpdateFrequency(frequency: VitalsUpdateFrequency) {
+        nativeConfigurationBuilder.setVitalsUpdateFrequency(frequency.native)
+    }
+
+    override fun setSessionListener(sessionListener: RumSessionListener) {
+        nativeConfigurationBuilder.setSessionListener(object : NativeRumSessionListener {
+            override fun onSessionStarted(sessionId: String, isDiscarded: Boolean) {
+                sessionListener.onSessionStarted(sessionId, isDiscarded)
+            }
+        })
+    }
+
+    fun trackNonFatalAnrs(enabled: Boolean) {
+        nativeConfigurationBuilder.trackNonFatalAnrs(enabled)
+    }
+
+    fun useViewTrackingStrategy(strategy: ViewTrackingStrategy?) {
+        nativeConfigurationBuilder.useViewTrackingStrategy(strategy.native)
+    }
+
+    fun trackUserInteractions(
+        touchTargetExtraAttributesProviders: Array<ViewAttributesProvider>,
+        interactionPredicate: InteractionPredicate
+    ) {
+        nativeConfigurationBuilder.trackUserInteractions(
+            touchTargetExtraAttributesProviders.map { it.native }.toTypedArray(),
+            interactionPredicate.native
+        )
+    }
+
+    override fun build(): NativeAndroidConfiguration {
+        return nativeConfigurationBuilder.build()
+    }
+}
+
+private val VitalsUpdateFrequency.native: NativeVitalsUpdateFrequency
+    get() = when (this) {
+        VitalsUpdateFrequency.FREQUENT -> NativeVitalsUpdateFrequency.FREQUENT
+        VitalsUpdateFrequency.AVERAGE -> NativeVitalsUpdateFrequency.AVERAGE
+        VitalsUpdateFrequency.RARE -> NativeVitalsUpdateFrequency.RARE
+        VitalsUpdateFrequency.NEVER -> NativeVitalsUpdateFrequency.NEVER
+    }
+
+private val ViewTrackingStrategy?.native: NativeViewTrackingStrategy?
+    get() {
+        val kmpStrategy = this ?: return null
+        return object : NativeViewTrackingStrategy {
+            override fun register(sdkCore: SdkCore, context: Context) {
+                kmpStrategy.register(context)
+            }
+
+            override fun unregister(context: Context?) {
+                kmpStrategy.unregister(context)
+            }
+        }
+    }
+
+private val ViewAttributesProvider.native: NativeViewAttributesProvider
+    get() {
+        val kmpProvider = this
+        return object : NativeViewAttributesProvider {
+            override fun extractAttributes(view: View, attributes: MutableMap<String, Any?>) {
+                kmpProvider.extractAttributes(view, attributes)
+            }
+        }
+    }
+
+private val InteractionPredicate.native: NativeInteractionPredicate
+    get() {
+        val kmpPredicate = this
+        return object : NativeInteractionPredicate {
+            override fun getTargetName(target: Any): String? = kmpPredicate.getTargetName(target)
+        }
+    }

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/AcceptAllActivities.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/AcceptAllActivities.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import android.app.Activity
+import com.datadog.android.rum.tracking.AcceptAllActivities
+import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
+
+/**
+ * A predefined [ComponentPredicate] which accepts all [Activity]  to be tracked as a RUM View event.
+ * This is the default behaviour for the [ActivityViewTrackingStrategy].
+ */
+class AcceptAllActivities : ComponentPredicate<Activity> {
+
+    private val nativeDelegate = AcceptAllActivities()
+
+    override fun accept(component: Activity): Boolean = nativeDelegate.accept(component)
+
+    override fun getViewName(component: Activity): String? = nativeDelegate.getViewName(component)
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/AcceptAllDefaultFragments.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/AcceptAllDefaultFragments.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+@file:Suppress("DEPRECATION")
+
+package com.datadog.kmp.rum.tracking
+
+import android.app.Fragment
+import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
+import com.datadog.android.rum.tracking.AcceptAllDefaultFragment as NativeAcceptAllDefaultFragments
+
+/**
+ * A predefined [ComponentPredicate] which accepts all [Fragment] to be tracked as RUM View event.
+ * This is the default behaviour for the [FragmentViewTrackingStrategy].
+ */
+class AcceptAllDefaultFragments : ComponentPredicate<Fragment> {
+
+    private val nativeDelegate = NativeAcceptAllDefaultFragments()
+
+    override fun accept(component: Fragment): Boolean = nativeDelegate.accept(component)
+
+    override fun getViewName(component: Fragment): String? = nativeDelegate.getViewName(component)
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/AcceptAllNavDestinations.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/AcceptAllNavDestinations.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import androidx.navigation.NavDestination
+import com.datadog.android.rum.tracking.NavigationViewTrackingStrategy
+import com.datadog.android.rum.tracking.AcceptAllNavDestinations as NativeAcceptAllNavDestinations
+
+/**
+ * A predefined [ComponentPredicate] which accepts all [NavDestination] to be tracked as a RUM View event.
+ * This is the default behaviour for the [NavigationViewTrackingStrategy].
+ */
+class AcceptAllNavDestinations : ComponentPredicate<NavDestination> {
+
+    private val nativeDelegate = NativeAcceptAllNavDestinations()
+
+    override fun accept(component: NavDestination): Boolean = nativeDelegate.accept(component)
+
+    override fun getViewName(component: NavDestination): String? = nativeDelegate.getViewName(component)
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/AcceptAllSupportFragments.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/AcceptAllSupportFragments.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import androidx.fragment.app.Fragment
+import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
+import com.datadog.android.rum.tracking.AcceptAllSupportFragments as NativeAcceptAllSupportFragments
+
+/**
+ * A predefined [ComponentPredicate] which accepts all [Fragment] to be tracked as RUM View
+ * event. This is the default behaviour of the [FragmentViewTrackingStrategy].
+ */
+class AcceptAllSupportFragments : ComponentPredicate<Fragment> {
+
+    private val nativeDelegate = NativeAcceptAllSupportFragments()
+
+    override fun accept(component: Fragment): Boolean = nativeDelegate.accept(component)
+
+    override fun getViewName(component: Fragment): String? = nativeDelegate.getViewName(component)
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ActivityViewTrackingStrategy.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ActivityViewTrackingStrategy.kt
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import android.app.Activity
+import android.content.Context
+import com.datadog.android.Datadog
+import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy as NativeActivityViewTrackingStrategy
+
+/**
+ * A [ViewTrackingStrategy] that will track [Activity] as RUM Views.
+ *
+ * Each activity's lifecycle will be monitored to start and stop RUM Views when relevant.
+ * @param trackExtras whether to track the Activity's Intent information (extra attributes,
+ * action, data URI)
+ * @param componentPredicate to accept the Activities that will be taken into account as
+ * valid RUM View events.
+ */
+class ActivityViewTrackingStrategy(
+    trackExtras: Boolean,
+    componentPredicate: ComponentPredicate<Activity> = AcceptAllActivities()
+) : ViewTrackingStrategy {
+
+    private val nativeDelegate = NativeActivityViewTrackingStrategy(
+        trackExtras,
+        componentPredicate.native
+    )
+
+    override fun register(context: Context) {
+        nativeDelegate.register(Datadog.getInstance(), context)
+    }
+
+    override fun unregister(context: Context?) {
+        nativeDelegate.unregister(context)
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ComponentPredicate.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ComponentPredicate.kt
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
+import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
+import com.datadog.android.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.rum.tracking.ComponentPredicate as NativeComponentPredicate
+
+/**
+ * Used to decide which Android component of your application should be considered
+ * as a RUM View Event instance in a [ViewTrackingStrategy].
+ * @see FragmentViewTrackingStrategy
+ * @see ActivityViewTrackingStrategy
+ * @see MixedViewTrackingStrategy
+ * @see NavigationViewTrackingStrategy
+ */
+interface ComponentPredicate<T> {
+    /**
+     * Decides whether the provided component should be considered as a RUM View.
+     * Make sure you are consistent when you validate a component otherwise you may experience
+     * some weird behaviours (e.g. by returning true in a first interrogation for a component
+     * followed by false in a second interrogation we might alter the data in the in progress
+     * View event or we might close the current valid View prematurely).
+     * @param component a component whose state changed
+     * @return true if you want the component to be tracked as a View, false otherwise
+     *
+     */
+    fun accept(component: T): Boolean
+
+    /**
+     * Sets a custom name for the tracked RUM View.
+     * @return the name to use for this view (if null or blank, the default will be used)
+     */
+    fun getViewName(component: T): String?
+}
+
+internal val <T> ComponentPredicate<T>.native: NativeComponentPredicate<T>
+    get() {
+        val kmpPredicate = this
+        return object : NativeComponentPredicate<T> {
+            override fun accept(component: T) = kmpPredicate.accept(component)
+
+            override fun getViewName(component: T) = kmpPredicate.getViewName(component)
+        }
+    }

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/FragmentViewTrackingStrategy.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/FragmentViewTrackingStrategy.kt
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import android.content.Context
+import androidx.fragment.app.Fragment
+import com.datadog.android.Datadog
+import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
+import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy as NativeFragmentViewTrackingStrategy
+
+/**
+ * A [ViewTrackingStrategy] that will track [Fragment]s as RUM Views.
+ *
+ * Each fragment's lifecycle will be monitored to start and stop RUM Views when relevant.
+ *
+ * **Note**: This version of the [FragmentViewTrackingStrategy] is compatible with
+ * the AndroidX Compat Library.
+ *
+ *  @param trackArguments whether we track Fragment arguments
+ *  @param supportFragmentComponentPredicate to accept the Androidx Fragments
+ *  that will be taken into account as valid RUM View events.
+ *  @param defaultFragmentComponentPredicate to accept the default Android Fragments
+ *  that will be taken into account as valid RUM View events.
+ */
+class FragmentViewTrackingStrategy(
+    trackArguments: Boolean,
+    supportFragmentComponentPredicate: ComponentPredicate<Fragment> =
+        AcceptAllSupportFragments(),
+    @Suppress("DEPRECATION")
+    defaultFragmentComponentPredicate: ComponentPredicate<android.app.Fragment> =
+        AcceptAllDefaultFragments()
+) : ViewTrackingStrategy {
+
+    private val nativeDelegate = NativeFragmentViewTrackingStrategy(
+        trackArguments,
+        supportFragmentComponentPredicate.native,
+        defaultFragmentComponentPredicate.native
+    )
+
+    override fun register(context: Context) {
+        nativeDelegate.register(Datadog.getInstance(), context)
+    }
+
+    override fun unregister(context: Context?) {
+        nativeDelegate.unregister(context)
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/InteractionPredicate.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/InteractionPredicate.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+/**
+ * Provides custom attributes for the events produced by the user action tracking strategy.
+ */
+interface InteractionPredicate {
+
+    /**
+     * Sets a custom name for the intercepted touch target.
+     * @return the name to use for this touch target (if null or blank, the default will be used)
+     */
+    fun getTargetName(target: Any): String?
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/MixedViewTrackingStrategy.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/MixedViewTrackingStrategy.kt
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import android.app.Activity
+import android.content.Context
+import androidx.fragment.app.Fragment
+import com.datadog.android.Datadog
+import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
+import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
+import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
+import com.datadog.android.rum.tracking.MixedViewTrackingStrategy as NativeMixedViewTrackingStrategy
+
+/**
+ * A [ViewTrackingStrategy] that will track [Activity] and [Fragment] as RUM View Events.
+ * This strategy will apply both the [ActivityViewTrackingStrategy]
+ * and the [FragmentViewTrackingStrategy] and will remain for you to decide whether to exclude
+ * some activities or fragments from tracking by providing an implementation for the right
+ * predicate in the constructor arguments.
+ * @see ActivityViewTrackingStrategy
+ * @see FragmentViewTrackingStrategy
+ * **Note**: This version of the [MixedViewTrackingStrategy] is compatible with
+ * the AndroidX Compat Library.
+ *
+ * @param trackExtras whether we track Activity/Fragment arguments (extra attributes,
+ *  * action, data URI)
+ * @param componentPredicate to accept the Activities that will be taken into account as
+ * valid RUM View events.
+ * @param supportFragmentComponentPredicate to accept the Androidx Fragments
+ * that will be taken into account as valid RUM View events.
+ * @param defaultFragmentComponentPredicate to accept the default Android Fragments
+ * that will be taken into account as valid RUM View events.
+ */
+class MixedViewTrackingStrategy(
+    trackExtras: Boolean,
+    componentPredicate: ComponentPredicate<Activity> = AcceptAllActivities(),
+    supportFragmentComponentPredicate: ComponentPredicate<Fragment> =
+        AcceptAllSupportFragments(),
+    @Suppress("DEPRECATION")
+    defaultFragmentComponentPredicate: ComponentPredicate<android.app.Fragment> =
+        AcceptAllDefaultFragments()
+) : ViewTrackingStrategy {
+
+    private val nativeDelegate = NativeMixedViewTrackingStrategy(
+        trackExtras,
+        componentPredicate.native,
+        supportFragmentComponentPredicate.native,
+        defaultFragmentComponentPredicate.native
+    )
+
+    override fun register(context: Context) {
+        nativeDelegate.register(Datadog.getInstance(), context)
+    }
+
+    override fun unregister(context: Context?) {
+        nativeDelegate.unregister(context)
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import android.app.Activity
+import android.content.Context
+import androidx.annotation.IdRes
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavDestination
+import com.datadog.android.Datadog
+import com.datadog.android.rum.tracking.NavigationViewTrackingStrategy as NativeNavigationViewTrackingStrategy
+
+/**
+ * A [ViewTrackingStrategy] that will track [Fragment]s within a NavigationHost
+ * as RUM Views.
+ *
+ * @param navigationViewId the id of the NavHost view within the hosting [Activity].
+ * @param trackArguments whether to track navigation arguments
+ * @param componentPredicate the predicate to keep/discard/rename the tracked [NavDestination]s
+ */
+class NavigationViewTrackingStrategy(
+    @IdRes navigationViewId: Int,
+    trackArguments: Boolean,
+    componentPredicate: ComponentPredicate<NavDestination> = AcceptAllNavDestinations()
+) : ViewTrackingStrategy {
+
+    private val nativeDelegate = NativeNavigationViewTrackingStrategy(
+        navigationViewId,
+        trackArguments,
+        componentPredicate.native
+    )
+
+    override fun register(context: Context) {
+        nativeDelegate.register(Datadog.getInstance(), context)
+    }
+
+    override fun unregister(context: Context?) {
+        nativeDelegate.unregister(context)
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ViewAttributesProvider.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ViewAttributesProvider.kt
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import android.view.View
+import com.datadog.android.rum.RumAttributes
+
+/**
+ * Provides the extra attributes for the  as Map<String,Any?>.
+ */
+interface ViewAttributesProvider {
+
+    /**
+     * Add extra attributes to the default attributes Map.
+     * @param view the [View].
+     * @param attributes the default attributes Map. Usually this contains some default
+     * attributes which are determined and added by the SDK. Please make sure you do not
+     * override any of these reserved attributes.
+     * @see [RumAttributes.ACTION_TARGET_RESOURCE_ID]
+     * @see [RumAttributes.ACTION_TARGET_CLASS_NAME]
+     */
+    fun extractAttributes(view: View, attributes: MutableMap<String, Any?>)
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ViewTrackingStrategy.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ViewTrackingStrategy.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import android.content.Context
+
+/**
+ * A TrackingStrategy dedicated to views tracking.
+ */
+interface ViewTrackingStrategy {
+    /**
+     * This method will register the tracking strategy to the current Context and SDK instance.
+     * @param context as [Context]
+     */
+    fun register(context: Context)
+
+    /**
+     * This method will unregister the tracking strategy from the current Context.
+     * @param context as [Context]
+     */
+    fun unregister(context: Context?)
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/internal/NoOpInteractionPredicate.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/internal/NoOpInteractionPredicate.kt
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking.internal
+
+import com.datadog.kmp.rum.tracking.InteractionPredicate
+
+internal class NoOpInteractionPredicate : InteractionPredicate {
+    override fun getTargetName(target: Any): String? = null
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilderTest.kt
@@ -1,0 +1,238 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration.internal
+
+import android.content.Context
+import android.view.View
+import com.datadog.kmp.rum.configuration.RumSessionListener
+import com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
+import com.datadog.kmp.rum.tracking.InteractionPredicate
+import com.datadog.kmp.rum.tracking.ViewAttributesProvider
+import com.datadog.kmp.rum.tracking.ViewTrackingStrategy
+import com.datadog.tools.unit.forge.BaseConfigurator
+import com.datadog.tools.unit.forge.exhaustiveAttributes
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.util.UUID
+import com.datadog.android.rum.RumConfiguration as NativeAndroidConfiguration
+import com.datadog.android.rum.RumConfiguration as NativeRumConfiguration
+import com.datadog.android.rum.RumSessionListener as NativeRumSessionListener
+import com.datadog.android.rum.configuration.VitalsUpdateFrequency as NativeVitalsUpdateFrequency
+import com.datadog.android.rum.tracking.InteractionPredicate as NativeInteractionPredicate
+import com.datadog.android.rum.tracking.ViewAttributesProvider as NativeViewAttributesProvider
+import com.datadog.android.rum.tracking.ViewTrackingStrategy as NativeViewTrackingStrategy
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(BaseConfigurator::class)
+internal class AndroidRumConfigurationBuilderTest {
+
+    private lateinit var testedBuilder: AndroidRumConfigurationBuilder
+
+    @Mock
+    lateinit var mockNativeRumConfigurationBuilder: NativeRumConfiguration.Builder
+
+    @BeforeEach
+    fun `set up`() {
+        testedBuilder = AndroidRumConfigurationBuilder(mockNativeRumConfigurationBuilder)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+setSessionSampleRate W setSessionSampleRate`(
+        @FloatForgery(min = 0f, max = 100f) fakeSessionSampleRate: Float
+    ) {
+        // When
+        testedBuilder.setSessionSampleRate(fakeSessionSampleRate)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).setSessionSampleRate(fakeSessionSampleRate)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+setTelemetrySampleRate W setTelemetrySampleRate`(
+        @FloatForgery(min = 0f, max = 100f) fakeTelemetrySampleRate: Float
+    ) {
+        // When
+        testedBuilder.setTelemetrySampleRate(fakeTelemetrySampleRate)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).setTelemetrySampleRate(fakeTelemetrySampleRate)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+trackLongTasks W trackLongTasks`(
+        @LongForgery(min = 0L) fakeLongTaskThresholdMs: Long
+    ) {
+        // When
+        testedBuilder.trackLongTasks(fakeLongTaskThresholdMs)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).trackLongTasks(fakeLongTaskThresholdMs)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+trackBackgroundEvents W trackBackgroundEvents`(
+        @BoolForgery fakeTrackBackgroundEvents: Boolean
+    ) {
+        // When
+        testedBuilder.trackBackgroundEvents(fakeTrackBackgroundEvents)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).trackBackgroundEvents(fakeTrackBackgroundEvents)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+trackFrustrations W trackFrustrations`(
+        @BoolForgery fakeTrackFrustrations: Boolean
+    ) {
+        // When
+        testedBuilder.trackFrustrations(fakeTrackFrustrations)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).trackFrustrations(fakeTrackFrustrations)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+setVitalsUpdateFrequency W setVitalsUpdateFrequency`(
+        @Forgery fakeVitalsUpdateFrequency: VitalsUpdateFrequency
+    ) {
+        // Given
+        val expectedValue = when (fakeVitalsUpdateFrequency) {
+            VitalsUpdateFrequency.NEVER -> NativeVitalsUpdateFrequency.NEVER
+            VitalsUpdateFrequency.RARE -> NativeVitalsUpdateFrequency.RARE
+            VitalsUpdateFrequency.AVERAGE -> NativeVitalsUpdateFrequency.AVERAGE
+            VitalsUpdateFrequency.FREQUENT -> NativeVitalsUpdateFrequency.FREQUENT
+        }
+        // When
+        testedBuilder.setVitalsUpdateFrequency(fakeVitalsUpdateFrequency)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).setVitalsUpdateFrequency(expectedValue)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+setSessionListener W setSessionListener`(
+        @Forgery fakeSessionId: UUID,
+        @BoolForgery fakeIsDiscarded: Boolean
+    ) {
+        // Given
+        val mockListener = mock<RumSessionListener>()
+
+        // When
+        testedBuilder.setSessionListener(mockListener)
+
+        // Then
+        argumentCaptor<NativeRumSessionListener> {
+            verify(mockNativeRumConfigurationBuilder).setSessionListener(capture())
+            firstValue.onSessionStarted(fakeSessionId.toString(), fakeIsDiscarded)
+
+            verify(mockListener).onSessionStarted(fakeSessionId.toString(), fakeIsDiscarded)
+        }
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+trackNonFatalAnrs W trackNonFatalAnrs`(
+        @BoolForgery fakeTrackNonFatalAnrs: Boolean
+    ) {
+        // When
+        testedBuilder.trackNonFatalAnrs(fakeTrackNonFatalAnrs)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).trackNonFatalAnrs(fakeTrackNonFatalAnrs)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+useViewTrackingStrategy W useViewTrackingStrategy`() {
+        // Given
+        val mockViewTrackingStrategy = mock<ViewTrackingStrategy>()
+
+        // When
+        testedBuilder.useViewTrackingStrategy(mockViewTrackingStrategy)
+
+        // Then
+        argumentCaptor<NativeViewTrackingStrategy> {
+            verify(mockNativeRumConfigurationBuilder).useViewTrackingStrategy(capture())
+            val mockContext = mock<Context>()
+            firstValue.register(sdkCore = mock(), mockContext)
+            firstValue.unregister(mockContext)
+
+            verify(mockViewTrackingStrategy).register(mockContext)
+            verify(mockViewTrackingStrategy).unregister(mockContext)
+        }
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+trackUserInteractions W trackUserInteractions`(
+        forge: Forge
+    ) {
+        // Given
+        val mockTouchTargetExtraAttributeProviders = forge.aList {
+            mock<ViewAttributesProvider>()
+        }.toTypedArray()
+        val mockInteractionPredicate = mock<InteractionPredicate>()
+
+        // When
+        testedBuilder.trackUserInteractions(mockTouchTargetExtraAttributeProviders, mockInteractionPredicate)
+
+        // Then
+        val attributesProvidersCaptor = argumentCaptor<Array<NativeViewAttributesProvider>>()
+        val interactionPredicateCaptor = argumentCaptor<NativeInteractionPredicate>()
+        verify(mockNativeRumConfigurationBuilder)
+            .trackUserInteractions(attributesProvidersCaptor.capture(), interactionPredicateCaptor.capture())
+
+        attributesProvidersCaptor.firstValue.let {
+            val mockView = mock<View>()
+            val fakeAttributes = forge.exhaustiveAttributes().toMutableMap()
+            assertThat(it).hasSameSizeAs(mockTouchTargetExtraAttributeProviders)
+            it.forEach {
+                it.extractAttributes(mockView, fakeAttributes)
+            }
+            mockTouchTargetExtraAttributeProviders.forEach {
+                verify(it).extractAttributes(mockView, fakeAttributes)
+            }
+        }
+
+        val fakeTarget = Any()
+        interactionPredicateCaptor.firstValue.getTargetName(fakeTarget)
+        verify(mockInteractionPredicate).getTargetName(fakeTarget)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+build W build`() {
+        // Given
+        val mockNativeConfiguration = mock<NativeAndroidConfiguration>()
+        whenever(mockNativeRumConfigurationBuilder.build()) doReturn mockNativeConfiguration
+
+        // When
+        val rumConfiguration = testedBuilder.build()
+
+        // Then
+        assertThat(rumConfiguration).isSameAs(mockNativeConfiguration)
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/Rum.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/Rum.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum
+
+import com.datadog.kmp.rum.configuration.RumConfiguration
+
+/**
+ * An entry point to Datadog RUM feature.
+ */
+expect object Rum {
+
+    /**
+     * Enables a RUM feature based on the configuration provided and registers RUM monitor.
+     *
+     * @param rumConfiguration Configuration to use for the feature.
+     */
+    fun enable(rumConfiguration: RumConfiguration)
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
@@ -1,0 +1,129 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration
+
+import com.datadog.kmp.rum.configuration.internal.PlatformRumConfigurationBuilder
+
+/**
+ * Describes configuration to be used for the RUM feature.
+ */
+class RumConfiguration internal constructor(internal val nativeConfiguration: Any) {
+
+    /**
+     * A Builder class for a [RumConfiguration].
+     */
+    class Builder {
+
+        internal val platformBuilder: PlatformRumConfigurationBuilder<*>
+
+        /**
+         * Creates a new instance of [Builder].
+         *
+         * @param applicationId your applicationId for RUM events
+         */
+        constructor(applicationId: String) : this(platformConfigurationBuilder(applicationId))
+
+        internal constructor(platformBuilder: PlatformRumConfigurationBuilder<*>) {
+            this.platformBuilder = platformBuilder
+        }
+
+        /**
+         * Sets the sample rate for RUM Sessions.
+         *
+         * @param sampleRate the sample rate must be a value between 0 and 100. A value of 0
+         * means no RUM event will be sent, 100 means all sessions will be kept.
+         */
+        fun setSessionSampleRate(sampleRate: Float): Builder {
+            platformBuilder.setSessionSampleRate(sampleRate)
+            return this
+        }
+
+        /**
+         * Sets the sample rate for Internal Telemetry (info related to the work of the
+         * SDK internals). Default value is 20.
+         *
+         * @param sampleRate the sample rate must be a value between 0 and 100. A value of 0
+         * means no telemetry will be sent, 100 means all telemetry will be kept.
+         */
+        fun setTelemetrySampleRate(sampleRate: Float): Builder {
+            platformBuilder.setTelemetrySampleRate(sampleRate)
+            return this
+        }
+
+        /**
+         * Enable long operations on the main thread to be tracked automatically.
+         * Any long running operation on the main thread will appear as Long Tasks in Datadog
+         * RUM Explorer
+         * @param longTaskThresholdMs the threshold in milliseconds above which a task running on
+         * the main thread is considered as a long task (default 100ms). Setting a
+         * value less than or equal to 0 disables the long task tracking
+         */
+        fun trackLongTasks(longTaskThresholdMs: Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder {
+            platformBuilder.trackLongTasks(longTaskThresholdMs)
+            return this
+        }
+
+        /**
+         * Enables/Disables tracking RUM events when no there is no active foreground RUM view.
+         *
+         * By default, background events are not tracked. Enabling this feature might increase the
+         * number of sessions tracked and impact your billing.
+         *
+         * @param enabled whether background events should be tracked in RUM.
+         */
+        fun trackBackgroundEvents(enabled: Boolean): Builder {
+            platformBuilder.trackBackgroundEvents(enabled)
+            return this
+        }
+
+        /**
+         * Enables/Disables tracking of frustration signals.
+         *
+         * By default frustration signals are tracked. Currently the SDK supports detecting
+         * error taps which occur when an error follows a user action tap.
+         *
+         * @param enabled whether frustration signals should be tracked in RUM.
+         */
+        fun trackFrustrations(enabled: Boolean): Builder {
+            platformBuilder.trackFrustrations(enabled)
+            return this
+        }
+
+        /**
+         * Allows to specify the frequency at which to update the mobile vitals
+         * data provided in the RUM View event.
+         * @param frequency as [VitalsUpdateFrequency]
+         * @see [VitalsUpdateFrequency]
+         */
+        fun setVitalsUpdateFrequency(frequency: VitalsUpdateFrequency): Builder {
+            platformBuilder.setVitalsUpdateFrequency(frequency)
+            return this
+        }
+
+        /**
+         * Sets the Session listener.
+         * @param sessionListener the listener to notify whenever a new Session starts.
+         */
+        fun setSessionListener(sessionListener: RumSessionListener): Builder {
+            platformBuilder.setSessionListener(sessionListener)
+            return this
+        }
+
+        /**
+         * Builds a [RumConfiguration] based on the current state of this Builder.
+         */
+        fun build(): RumConfiguration {
+            return RumConfiguration(platformBuilder.build())
+        }
+
+        private companion object {
+            const val DEFAULT_LONG_TASK_THRESHOLD_MS = 100L
+        }
+    }
+}
+
+internal expect fun platformConfigurationBuilder(applicationId: String): PlatformRumConfigurationBuilder<Any>

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumSessionListener.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumSessionListener.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration
+
+/**
+ * An interface to get informed whenever a new session is starting,
+ * providing you with Datadog's session id.
+ */
+fun interface RumSessionListener {
+
+    /**
+     * Called whenever a new session is started.
+     * @param sessionId the Session's id (matching the `session.id` attribute in Datadog's RUM events)
+     * @param isDiscarded whether or not the session is discarded by the sample rate
+     * (when `true` it means no event in this session will be kept).
+     */
+    fun onSessionStarted(sessionId: String, isDiscarded: Boolean)
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/VitalsUpdateFrequency.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/VitalsUpdateFrequency.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration
+
+/**
+ * Defines the frequency at which mobile vitals monitor updates the data.
+ */
+enum class VitalsUpdateFrequency {
+    /** Every 100 milliseconds. */
+    FREQUENT,
+
+    /** Every 500 milliseconds. This is the default frequency. */
+    AVERAGE,
+
+    /** Every 1000 milliseconds. */
+    RARE,
+
+    /** No data will be sent for mobile vitals. */
+    NEVER
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/internal/PlatformRumConfigurationBuilder.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/internal/PlatformRumConfigurationBuilder.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration.internal
+
+import com.datadog.kmp.rum.configuration.RumSessionListener
+import com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
+
+internal interface PlatformRumConfigurationBuilder<out T : Any> {
+
+    fun setSessionSampleRate(sampleRate: Float)
+
+    fun setTelemetrySampleRate(sampleRate: Float)
+
+    fun trackLongTasks(longTaskThresholdMs: Long)
+
+    fun trackBackgroundEvents(enabled: Boolean)
+
+    fun trackFrustrations(enabled: Boolean)
+
+    fun setVitalsUpdateFrequency(frequency: VitalsUpdateFrequency)
+
+    fun setSessionListener(sessionListener: RumSessionListener)
+
+    fun build(): T
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/commonTest/kotlin/com/datadog/kmp/rum/configuration/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/commonTest/kotlin/com/datadog/kmp/rum/configuration/RumConfigurationBuilderTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration
+
+import com.datadog.kmp.rum.configuration.internal.PlatformRumConfigurationBuilder
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+class RumConfigurationBuilderTest {
+
+    private val mockPlatformRumConfigurationBuilder = mock<PlatformRumConfigurationBuilder<*>>()
+
+    private val testedRumConfigurationBuilder = RumConfiguration.Builder(mockPlatformRumConfigurationBuilder)
+
+    @Test
+    fun `M return RumConfiguration W build`() {
+        // Given
+        val fakeNativeConfiguration = Any()
+        every { mockPlatformRumConfigurationBuilder.build() } returns fakeNativeConfiguration
+
+        // When
+        val rumConfiguration = testedRumConfigurationBuilder.build()
+
+        // Then
+        assertSame(fakeNativeConfiguration, rumConfiguration.nativeConfiguration)
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+setSessionSampleRate W setSessionSampleRate`() {
+        // Given
+        val fakeSessionSampleRate = 42f
+
+        // When
+        testedRumConfigurationBuilder.setSessionSampleRate(fakeSessionSampleRate)
+
+        // Then
+        verify {
+            mockPlatformRumConfigurationBuilder.setSessionSampleRate(fakeSessionSampleRate)
+        }
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+setTelemetrySampleRate W setTelemetrySampleRate`() {
+        // Given
+        val fakeTelemetrySampleRate = 42f
+
+        // When
+        testedRumConfigurationBuilder.setTelemetrySampleRate(fakeTelemetrySampleRate)
+
+        // Then
+        verify {
+            mockPlatformRumConfigurationBuilder.setTelemetrySampleRate(fakeTelemetrySampleRate)
+        }
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+trackLongTasks W trackLongTasks`() {
+        // Given
+        val fakeLongTasksThreshold = 250L
+
+        // When
+        testedRumConfigurationBuilder.trackLongTasks(fakeLongTasksThreshold)
+
+        // Then
+        verify {
+            mockPlatformRumConfigurationBuilder.trackLongTasks(fakeLongTasksThreshold)
+        }
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+trackBackgroundEvents W trackBackgroundEvents`() {
+        // Given
+        val fakeTrackBackgroundEvents = true
+
+        // When
+        testedRumConfigurationBuilder.trackBackgroundEvents(fakeTrackBackgroundEvents)
+
+        // Then
+        verify {
+            mockPlatformRumConfigurationBuilder.trackBackgroundEvents(fakeTrackBackgroundEvents)
+        }
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+trackFrustrations W trackFrustrations`() {
+        // Given
+        val fakeTrackFrustrations = true
+
+        // When
+        testedRumConfigurationBuilder.trackFrustrations(fakeTrackFrustrations)
+
+        // Then
+        verify {
+            mockPlatformRumConfigurationBuilder.trackFrustrations(fakeTrackFrustrations)
+        }
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+setVitalsUpdateFrequency W setVitalsUpdateFrequency`() {
+        // Given
+        val fakeVitalsUpdateFrequency = VitalsUpdateFrequency.RARE
+
+        // When
+        testedRumConfigurationBuilder.setVitalsUpdateFrequency(fakeVitalsUpdateFrequency)
+
+        // Then
+        verify {
+            mockPlatformRumConfigurationBuilder.setVitalsUpdateFrequency(fakeVitalsUpdateFrequency)
+        }
+    }
+
+    @Test
+    fun `M call platform RUM configuration builder+setSessionListener W setSessionListener`() {
+        // Given
+        val fakeSessionListener = RumSessionListener { _, _ -> }
+
+        // When
+        testedRumConfigurationBuilder.setSessionListener(fakeSessionListener)
+
+        // Then
+        verify {
+            mockPlatformRumConfigurationBuilder.setSessionListener(fakeSessionListener)
+        }
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/Rum.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/Rum.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum
+
+import cocoapods.DatadogObjc.DDRUM
+import cocoapods.DatadogObjc.DDRUMConfiguration
+import com.datadog.kmp.rum.configuration.RumConfiguration
+
+/**
+ * An entry point to Datadog RUM feature.
+ */
+actual object Rum {
+    /**
+     * Enables a RUM feature based on the configuration provided and registers RUM monitor.
+     *
+     * @param rumConfiguration Configuration to use for the feature.
+     */
+    actual fun enable(rumConfiguration: RumConfiguration) {
+        DDRUM.enableWith(rumConfiguration.nativeConfiguration as DDRUMConfiguration)
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
@@ -1,0 +1,58 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration
+
+import com.datadog.kmp.rum.configuration.internal.IOSRumConfigurationBuilder
+import com.datadog.kmp.rum.configuration.internal.PlatformRumConfigurationBuilder
+import com.datadog.kmp.rum.tracking.DefaultUIKitRUMActionsPredicate
+import com.datadog.kmp.rum.tracking.DefaultUIKitRUMViewsPredicate
+import com.datadog.kmp.rum.tracking.UIKitRUMActionsPredicate
+import com.datadog.kmp.rum.tracking.UIKitRUMViewsPredicate
+
+/**
+ * Enable automatic tracking of `UIViewControllers` as RUM views.
+ *
+ * RUM will query this predicate for each [platform.UIKit.UIViewController] presented in the app. The predicate
+ * implementation should return RUM view parameters if the given controller should start a view, or `null` to ignore it.
+ *
+ * [DefaultUIKitRUMViewsPredicate] will be used by default, or you can create your own predicate
+ * by implementing [UIKitRUMViewsPredicate].
+ *
+ * Note: Automatic RUM views tracking involves swizzling the `UIViewController` lifecycle methods.
+ */
+fun RumConfiguration.Builder.trackUiKitViews(
+    uiKitViewsPredicate: UIKitRUMViewsPredicate = DefaultUIKitRUMViewsPredicate()
+): RumConfiguration.Builder {
+    nativePlatformBuilder.setUiKitViewsPredicate(uiKitViewsPredicate)
+    return this
+}
+
+/**
+ * Enable automatic tracking of [platform.UIKit.UITouch] events as RUM actions.
+ *
+ * RUM will query this predicate for each [platform.UIKit.UIView] that the user interacts with. The predicate
+ * implementation should return RUM action parameters if the given interaction should be accepted,
+ * or `null` to ignore it.
+ * Touch events on the keyboard are ignored for privacy reasons.
+ *
+ * [DefaultUIKitRUMActionsPredicate] will be used by default, or you can create your own predicate by
+ * implementing [UIKitRUMActionsPredicate].
+ *
+ * Note: Automatic RUM action tracking involves swizzling the `UIApplication.sendEvent(_:)` method.
+ */
+fun RumConfiguration.Builder.trackUiKitActions(
+    uiKitActionsPredicate: UIKitRUMActionsPredicate = DefaultUIKitRUMActionsPredicate()
+): RumConfiguration.Builder {
+    nativePlatformBuilder.setUiKitActionsPredicate(uiKitActionsPredicate)
+    return this
+}
+
+internal actual fun platformConfigurationBuilder(applicationId: String): PlatformRumConfigurationBuilder<Any> =
+    IOSRumConfigurationBuilder(applicationId)
+
+private val RumConfiguration.Builder.nativePlatformBuilder
+    get() = platformBuilder as IOSRumConfigurationBuilder

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/configuration/internal/IOSRumConfigurationBuilder.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/configuration/internal/IOSRumConfigurationBuilder.kt
@@ -1,0 +1,138 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration.internal
+
+import cocoapods.DatadogObjc.DDDefaultUIKitRUMActionsPredicate
+import cocoapods.DatadogObjc.DDRUMAction
+import cocoapods.DatadogObjc.DDRUMConfiguration
+import cocoapods.DatadogObjc.DDRUMView
+import cocoapods.DatadogObjc.DDRUMVitalsFrequency
+import cocoapods.DatadogObjc.DDRUMVitalsFrequencyAverage
+import cocoapods.DatadogObjc.DDRUMVitalsFrequencyFrequent
+import cocoapods.DatadogObjc.DDRUMVitalsFrequencyNever
+import cocoapods.DatadogObjc.DDRUMVitalsFrequencyRare
+import cocoapods.DatadogObjc.DDUIKitRUMViewsPredicateProtocol
+import com.datadog.kmp.rum.configuration.RumSessionListener
+import com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
+import com.datadog.kmp.rum.tracking.DefaultUIKitRUMActionsPredicate
+import com.datadog.kmp.rum.tracking.DefaultUIKitRUMViewsPredicate
+import com.datadog.kmp.rum.tracking.UIKitRUMActionsPredicate
+import com.datadog.kmp.rum.tracking.UIKitRUMViewsPredicate
+import platform.UIKit.UIView
+import platform.UIKit.UIViewController
+import platform.darwin.NSObject
+
+internal class IOSRumConfigurationBuilder : PlatformRumConfigurationBuilder<DDRUMConfiguration> {
+
+    private val nativeConfiguration: DDRUMConfiguration
+
+    internal constructor(applicationId: String) : this(DDRUMConfiguration(applicationId))
+
+    internal constructor(nativeConfiguration: DDRUMConfiguration) {
+        this.nativeConfiguration = nativeConfiguration
+    }
+
+    override fun setSessionSampleRate(sampleRate: Float) {
+        nativeConfiguration.setSessionSampleRate(sampleRate)
+    }
+
+    override fun setTelemetrySampleRate(sampleRate: Float) {
+        nativeConfiguration.setTelemetrySampleRate(sampleRate)
+    }
+
+    override fun trackLongTasks(longTaskThresholdMs: Long) {
+        // iOS takes this parameter in seconds
+        nativeConfiguration.setLongTaskThreshold(longTaskThresholdMs.toDouble() / MILLISECONDS_IN_SECOND)
+    }
+
+    override fun trackBackgroundEvents(enabled: Boolean) {
+        nativeConfiguration.setTrackBackgroundEvents(enabled)
+    }
+
+    override fun trackFrustrations(enabled: Boolean) {
+        nativeConfiguration.setTrackFrustrations(enabled)
+    }
+
+    override fun setVitalsUpdateFrequency(frequency: VitalsUpdateFrequency) {
+        nativeConfiguration.setVitalsUpdateFrequency(frequency.native)
+    }
+
+    override fun setSessionListener(sessionListener: RumSessionListener) {
+        nativeConfiguration.setOnSessionStart { sessionId, isDiscarded ->
+            // in iOS SDK source code, sessionId is String, not String?. But by some reason KMP generates
+            // binding with String? type.
+            if (sessionId != null) {
+                sessionListener.onSessionStarted(sessionId, isDiscarded)
+            }
+        }
+    }
+
+    fun setUiKitViewsPredicate(uiKitViewsPredicate: UIKitRUMViewsPredicate) {
+        val nativePredicate = if (uiKitViewsPredicate is DefaultUIKitRUMViewsPredicate) {
+            // just a short path to avoid creating unnecessary layers. NB: if DefaultUIKitRUMViewsPredicate becomes
+            // open, it is better to remove this branch, because its behavior may become different
+            // from the wrapped value
+            uiKitViewsPredicate.nativeDelegate
+        } else {
+            object : NSObject(), DDUIKitRUMViewsPredicateProtocol {
+                override fun rumViewFor(viewController: UIViewController): DDRUMView? {
+                    val rumView = uiKitViewsPredicate.createView(viewController) ?: return null
+                    return DDRUMView(
+                        rumView.name,
+                        rumView.attributes.mapKeys {
+                            @Suppress("USELESS_CAST")
+                            it.key as Any
+                        }
+                    )
+                }
+            }
+        }
+        nativeConfiguration.setUiKitViewsPredicate(nativePredicate)
+    }
+
+    fun setUiKitActionsPredicate(uiKitActionsPredicate: UIKitRUMActionsPredicate) {
+        val nativePredicate = if (uiKitActionsPredicate is DefaultUIKitRUMActionsPredicate) {
+            // just a short path to avoid creating unnecessary layers. NB: if DefaultUIKitRUMActionsPredicate becomes
+            // open, it is better to remove this branch, because its behavior may become different
+            // from the wrapped value
+            uiKitActionsPredicate.nativeDelegate
+        } else {
+            // TODO RUM-4818 by some reason the object which just implements DDUIKitRUMActionsPredicateProtocol cannot
+            //  be retrieved once it is successfully set. So extending DDDefaultUIKitRUMActionsPredicate instead (which
+            //  implements the same protocol, but on the Swift/ObjC side)
+            object : DDDefaultUIKitRUMActionsPredicate() {
+                override fun rumActionWithTargetView(targetView: UIView): DDRUMAction? {
+                    val rumAction = uiKitActionsPredicate.createAction(targetView) ?: return null
+                    return DDRUMAction(
+                        rumAction.name,
+                        rumAction.attributes.mapKeys {
+                            @Suppress("USELESS_CAST")
+                            it.key as Any
+                        }
+                    )
+                }
+            }
+        }
+        nativeConfiguration.setUiKitActionsPredicate(nativePredicate)
+    }
+
+    override fun build(): DDRUMConfiguration {
+        return nativeConfiguration
+    }
+
+    companion object {
+        const val MILLISECONDS_IN_SECOND = 1000
+    }
+}
+
+private val VitalsUpdateFrequency.native: DDRUMVitalsFrequency
+    get() = when (this) {
+        VitalsUpdateFrequency.FREQUENT -> DDRUMVitalsFrequencyFrequent
+        VitalsUpdateFrequency.AVERAGE -> DDRUMVitalsFrequencyAverage
+        VitalsUpdateFrequency.RARE -> DDRUMVitalsFrequencyRare
+        VitalsUpdateFrequency.NEVER -> DDRUMVitalsFrequencyNever
+    }

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/DefaultUIKitRUMActionsPredicate.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/DefaultUIKitRUMActionsPredicate.kt
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import cocoapods.DatadogObjc.DDDefaultUIKitRUMActionsPredicate
+import platform.UIKit.UIView
+
+/**
+ * Default implementation of [UIKitRUMActionsPredicate].
+ * It names  RUM Actions by the `accessibilityIdentifier` or `className` otherwise.
+ */
+class DefaultUIKitRUMActionsPredicate : UIKitRUMActionsPredicate {
+
+    internal val nativeDelegate = DDDefaultUIKitRUMActionsPredicate()
+
+    /** @inheritdoc */
+    override fun createAction(targetView: UIView): RumAction? {
+        val nativeView = nativeDelegate.rumActionWithTargetView(targetView) ?: return null
+        return RumAction(
+            nativeView.name(),
+            // Swift has it like [String,Any], but KMP generates type [Any?,*]
+            nativeView.attributes()
+                .filterKeys { it is String }
+                .mapKeys {
+                    it.key as String
+                }
+        )
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/DefaultUIKitRUMViewsPredicate.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/DefaultUIKitRUMViewsPredicate.kt
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import cocoapods.DatadogObjc.DDDefaultUIKitRUMViewsPredicate
+import platform.UIKit.UIViewController
+
+/**
+ * Default implementation of [UIKitRUMViewsPredicate].
+ * It names  RUM Views by the names of their [UIViewController] subclasses.
+ */
+class DefaultUIKitRUMViewsPredicate : UIKitRUMViewsPredicate {
+
+    internal val nativeDelegate = DDDefaultUIKitRUMViewsPredicate()
+
+    /** @inheritdoc */
+    override fun createView(viewController: UIViewController): RumView? {
+        val nativeView = nativeDelegate.rumViewFor(viewController) ?: return null
+        return RumView(
+            nativeView.name(),
+            // Swift has it like [String,Any], but KMP generates type [Any?,*]
+            nativeView.attributes()
+                .filterKeys { it is String }
+                .mapKeys {
+                    it.key as String
+                }
+        )
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/RumAction.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/RumAction.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+/**
+ * A description of the RUM Action returned from the `UIKitRUMActionsPredicate`.
+ *
+ * @param name the RUM Action name, appearing as `Action NAME` in RUM Explorer. If no name is given, default one will be used.
+ * @param attributes additional attributes to associate with the RUM Action.
+ */
+data class RumAction(internal val name: String, internal val attributes: Map<String, Any?>)

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/RumView.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/RumView.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+/**
+ * A description of the RUM View returned from the `UIKitRUMViewsPredicate`.
+ *
+ * @param name The RUM View name, appearing as `VIEW NAME` in RUM Explorer.
+ * @param attributes Additional attributes to associate with the RUM View.
+ */
+data class RumView(internal val name: String, internal val attributes: Map<String, Any?>)

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/UIKitRUMActionsPredicate.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/UIKitRUMActionsPredicate.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import platform.UIKit.UIView
+
+/**
+ * The predicate deciding if the RUM Action should be recorded.
+ */
+fun interface UIKitRUMActionsPredicate {
+    /**
+     * Creates a [RumAction] instance from the given instance of the [UIView].
+     *
+     * @param targetView an instance of the [UIView] which received the action.
+     * @return RUM Action if it should be recorded, `null` otherwise.
+     */
+    fun createAction(targetView: UIView): RumAction?
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/UIKitRUMViewsPredicate.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosMain/kotlin/com/datadog/kmp/rum/tracking/UIKitRUMViewsPredicate.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.tracking
+
+import platform.UIKit.UIViewController
+
+/**
+ * The predicate deciding if the RUM View should be started or ended for given instance of the [UIViewController].
+ */
+fun interface UIKitRUMViewsPredicate {
+    /**
+     * Creates a [RumView] instance from the given instance of the [UIViewController].
+     *
+     * @param viewController an instance of the view controller noticed by the SDK.
+     * @return RUM View parameters if received view controller should start/end the RUM View, `null` otherwise.
+     */
+    fun createView(viewController: UIViewController): RumView?
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosTest/kotlin/com/datadog/kmp/rum/configuration/internal/IOSRumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosTest/kotlin/com/datadog/kmp/rum/configuration/internal/IOSRumConfigurationBuilderTest.kt
@@ -1,0 +1,216 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration.internal
+
+import cocoapods.DatadogObjc.DDRUMConfiguration
+import cocoapods.DatadogObjc.DDRUMVitalsFrequencyAverage
+import cocoapods.DatadogObjc.DDRUMVitalsFrequencyFrequent
+import cocoapods.DatadogObjc.DDRUMVitalsFrequencyNever
+import cocoapods.DatadogObjc.DDRUMVitalsFrequencyRare
+import com.datadog.kmp.rum.configuration.RumSessionListener
+import com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
+import com.datadog.kmp.rum.tracking.RumAction
+import com.datadog.kmp.rum.tracking.RumView
+import com.datadog.kmp.rum.tracking.UIKitRUMActionsPredicate
+import com.datadog.kmp.rum.tracking.UIKitRUMViewsPredicate
+import dev.mokkery.mock
+import dev.mokkery.verify
+import platform.UIKit.UIView
+import platform.UIKit.UIViewController
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class IOSRumConfigurationBuilderTest {
+
+    private val fakeNativeRumConfiguration = DDRUMConfiguration("fake-app-id")
+
+    private val testedBuilder = IOSRumConfigurationBuilder(fakeNativeRumConfiguration)
+
+    @Test
+    fun `M set session sample rate W setSessionSampleRate`() {
+        // Given
+        val fakeSessionSampleRate = randomFloat(from = 0f, until = 100f)
+
+        // When
+        testedBuilder.setSessionSampleRate(fakeSessionSampleRate)
+
+        // Then
+        assertEquals(fakeSessionSampleRate, fakeNativeRumConfiguration.sessionSampleRate())
+    }
+
+    @Test
+    fun `M set telemetry sample rate W setTelemetrySampleRate`() {
+        // Given
+        val fakeTelemetrySampleRate = randomFloat(from = 0f, until = 100f)
+
+        // When
+        testedBuilder.setTelemetrySampleRate(fakeTelemetrySampleRate)
+
+        // Then
+        assertEquals(fakeTelemetrySampleRate, fakeNativeRumConfiguration.telemetrySampleRate())
+    }
+
+    @Test
+    fun `M set long task threshold W trackLongTasks`() {
+        // Given
+        val fakeLongTaskThresholdMs = randomLong(from = 0L)
+
+        // When
+        testedBuilder.trackLongTasks(fakeLongTaskThresholdMs)
+
+        // Then
+        assertEquals(fakeLongTaskThresholdMs.toDouble(), fakeNativeRumConfiguration.longTaskThreshold() * 1000)
+    }
+
+    @Test
+    fun `M set track background events W trackBackgroundEvents`() {
+        // Given
+        val fakeTrackBackgroundEvents = randomBoolean()
+
+        // When
+        testedBuilder.trackBackgroundEvents(fakeTrackBackgroundEvents)
+
+        // Then
+        assertEquals(fakeTrackBackgroundEvents, fakeNativeRumConfiguration.trackBackgroundEvents())
+    }
+
+    @Test
+    fun `M set track frustrations W trackFrustrations`() {
+        // Given
+        val fakeTrackFrustrations = randomBoolean()
+
+        // When
+        testedBuilder.trackFrustrations(fakeTrackFrustrations)
+
+        // Then
+        assertEquals(fakeTrackFrustrations, fakeNativeRumConfiguration.trackFrustrations())
+    }
+
+    @Test
+    fun `M set vitals update frequency W setVitalsUpdateFrequency`() {
+        // Given
+        val fakeFrequency = randomEnumValue<VitalsUpdateFrequency>()
+
+        // When
+        testedBuilder.setVitalsUpdateFrequency(fakeFrequency)
+
+        // Then
+        val actualFrequency = fakeNativeRumConfiguration.vitalsUpdateFrequency().run {
+            when (this) {
+                DDRUMVitalsFrequencyNever -> VitalsUpdateFrequency.NEVER
+                DDRUMVitalsFrequencyRare -> VitalsUpdateFrequency.RARE
+                DDRUMVitalsFrequencyAverage -> VitalsUpdateFrequency.AVERAGE
+                DDRUMVitalsFrequencyFrequent -> VitalsUpdateFrequency.FREQUENT
+                else -> throw IllegalArgumentException("Unknown native vitals update frequency value = $this")
+            }
+        }
+        assertEquals(fakeFrequency, actualFrequency)
+    }
+
+    @Test
+    fun `M set session listener W setSessionListener`() {
+        // Given
+        val mockListener = mock<RumSessionListener>()
+        val fakeSessionId = "fake-session-id"
+        val fakeIsDiscarded = randomBoolean()
+
+        // When
+        testedBuilder.setSessionListener(mockListener)
+        fakeNativeRumConfiguration.onSessionStart()?.invoke(fakeSessionId, fakeIsDiscarded)
+
+        // Then
+        verify {
+            mockListener.onSessionStarted(fakeSessionId, fakeIsDiscarded)
+        }
+    }
+
+    @Test
+    fun `M set UIKit views predicate W setUiKitViewsPredicate`() {
+        // Given
+        val fakeViewName = "fake-view-name"
+        val fakeViewAttributes = exhaustiveAttributes()
+        val fakeRumView = RumView(fakeViewName, fakeViewAttributes)
+        val stubPredicate = UIKitRUMViewsPredicate { fakeRumView }
+
+        // When
+        testedBuilder.setUiKitViewsPredicate(stubPredicate)
+
+        // Then
+        val nativeRumView = checkNotNull(fakeNativeRumConfiguration.uiKitViewsPredicate())
+            .rumViewFor(UIViewController())
+        checkNotNull(nativeRumView)
+        assertEquals(fakeViewName, nativeRumView.name())
+        assertEquals(
+            expected = fakeViewAttributes,
+            actual = nativeRumView.attributes().mapKeys {
+                it.key as String
+            }
+        )
+    }
+
+    @Test
+    fun `M set UIKit actions predicate W setUiKitActionsPredicate`() {
+        // Given
+        val fakeActionName = "fake-action-name"
+        val fakeActionAttributes = exhaustiveAttributes()
+        val fakeRumAction = RumAction(fakeActionName, fakeActionAttributes)
+        val stubPredicate = UIKitRUMActionsPredicate { fakeRumAction }
+
+        // When
+        testedBuilder.setUiKitActionsPredicate(stubPredicate)
+
+        // Then
+        val nativeRumAction = checkNotNull(fakeNativeRumConfiguration.uiKitActionsPredicate())
+            .rumActionWithTargetView(UIView())
+        checkNotNull(nativeRumAction)
+        assertEquals(fakeActionName, nativeRumAction.name())
+        assertEquals(
+            expected = fakeActionAttributes,
+            actual = nativeRumAction.attributes().mapKeys {
+                it.key as String
+            }
+        )
+    }
+
+    @Test
+    fun `M return native configuration W build`() {
+        // When
+        val nativeConfiguration = testedBuilder.build()
+
+        // Then
+        assertSame(fakeNativeRumConfiguration, nativeConfiguration)
+    }
+
+    // region private
+
+    private fun randomBoolean(): Boolean = Random.nextBoolean()
+
+    private fun randomFloat(from: Float = -Float.MAX_VALUE, until: Float = Float.MAX_VALUE): Float =
+        Random.nextDouble(from.toDouble(), until.toDouble()).toFloat()
+
+    private fun randomLong(from: Long = Long.MIN_VALUE, until: Long = Long.MAX_VALUE): Long =
+        Random.nextLong(from, until)
+
+    private inline fun <reified T : Enum<T>> randomEnumValue(): T {
+        val values = enumValues<T>()
+        return values[Random.nextInt(values.size)]
+    }
+
+    private fun exhaustiveAttributes(): Map<String, Any?> {
+        return mapOf(
+            "string-key" to "value",
+            "long-key" to randomLong(),
+            "float-key" to randomFloat(),
+            "object-key" to Any(),
+            "null-key" to null
+        )
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosTest/kotlin/com/datadog/kmp/rum/configuration/tracking/DefaultUIKitRUMActionsPredicateTest.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosTest/kotlin/com/datadog/kmp/rum/configuration/tracking/DefaultUIKitRUMActionsPredicateTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration.tracking
+
+import com.datadog.kmp.rum.tracking.DefaultUIKitRUMActionsPredicate
+import platform.UIKit.UIView
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DefaultUIKitRUMActionsPredicateTest {
+
+    @Test
+    fun `M call native default UIKit RUM actions predicate W createAction`() {
+        // Given
+        val testedInstance = DefaultUIKitRUMActionsPredicate()
+        val fakeView = UIView()
+
+        // When
+        val rumAction = testedInstance.createAction(fakeView)
+
+        // Then
+        checkNotNull(rumAction)
+        assertEquals("UIView", rumAction.name)
+        assertTrue(rumAction.attributes.isEmpty())
+    }
+}

--- a/features/dd-sdk-kotlin-multiplatform-rum/src/iosTest/kotlin/com/datadog/kmp/rum/configuration/tracking/DefaultUIKitRUMViewsPredicateTest.kt
+++ b/features/dd-sdk-kotlin-multiplatform-rum/src/iosTest/kotlin/com/datadog/kmp/rum/configuration/tracking/DefaultUIKitRUMViewsPredicateTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration.tracking
+
+import com.datadog.kmp.rum.tracking.DefaultUIKitRUMViewsPredicate
+import kotlinx.cinterop.BetaInteropApi
+import platform.UIKit.UIViewController
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DefaultUIKitRUMViewsPredicateTest {
+
+    @OptIn(BetaInteropApi::class)
+    @Test
+    fun `M call native default UIKit RUM views predicate W createView`() {
+        // Given
+        val testedInstance = DefaultUIKitRUMViewsPredicate()
+        val fakeViewController = NonUIKitViewController()
+        val expectedViewName = fakeViewController.`class`().toString()
+
+        // When
+        val rumView = testedInstance.createView(fakeViewController)
+
+        // Then
+        checkNotNull(rumView)
+        assertEquals(expectedViewName, rumView.name)
+        assertTrue(rumView.attributes.isEmpty())
+    }
+
+    class NonUIKitViewController : UIViewController(nibName = null, bundle = null)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,14 @@
 [versions]
-agp = "8.4.0"
+agp = "8.4.1"
 kotlin = "1.9.24"
 compose = "1.6.6"
 compose-compiler = "1.5.14"
 compose-material3 = "1.1.2"
+androidx-fragment = "1.5.1"
+androidx-navigation = "2.3.0"
 androidx-activityCompose = "1.8.0"
-datadog-android = "2.8.0"
-datadog-ios = "2.11.0"
+datadog-android = "2.10.1"
+datadog-ios = "2.12.0"
 dependencyLicense = "0.2"
 kotlinGrammarParser = "0.1.0"
 
@@ -23,6 +25,8 @@ mokkery = "1.9.24-1.7.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment" }
+androidx-navigation-runtime = { module = "androidx.navigation:navigation-runtime", version.ref = "androidx-navigation" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.ddSdkKotlinMultiplatformCore)
             api(projects.features.ddSdkKotlinMultiplatformLogs)
+            api(projects.features.ddSdkKotlinMultiplatformRum)
         }
     }
 }

--- a/sample/shared/src/androidMain/kotlin/com/datadog/kmp/sample/Utils.android.kt
+++ b/sample/shared/src/androidMain/kotlin/com/datadog/kmp/sample/Utils.android.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.sample
+
+import com.datadog.kmp.rum.configuration.RumConfiguration
+import com.datadog.kmp.rum.configuration.trackNonFatalAnrs
+import com.datadog.kmp.rum.configuration.trackUserInteractions
+import com.datadog.kmp.rum.configuration.useViewTrackingStrategy
+import com.datadog.kmp.rum.tracking.ActivityViewTrackingStrategy
+
+internal actual fun platformSpecificSetup(rumConfigurationBuilder: RumConfiguration.Builder) {
+    with(rumConfigurationBuilder) {
+        useViewTrackingStrategy(ActivityViewTrackingStrategy(trackExtras = true))
+        trackUserInteractions()
+        trackNonFatalAnrs(true)
+    }
+}

--- a/sample/shared/src/iosMain/kotlin/com/datadog/kmp/sample/Utils.ios.kt
+++ b/sample/shared/src/iosMain/kotlin/com/datadog/kmp/sample/Utils.ios.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.sample
+
+import com.datadog.kmp.rum.configuration.RumConfiguration
+import com.datadog.kmp.rum.configuration.trackUiKitActions
+import com.datadog.kmp.rum.configuration.trackUiKitViews
+
+internal actual fun platformSpecificSetup(rumConfigurationBuilder: RumConfiguration.Builder) {
+    with(rumConfigurationBuilder) {
+        trackUiKitViews()
+        trackUiKitActions()
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR implement `Rum` and `RumConfiguration` classes which are needed to enable RUM feature. Implementation of `RumMonitor` will come in another PR.

Methods of RUM configuration implemented:

* common ones:
  * `setSessionSampleRate`
  * `setTelemetrySampleRate`
  * `trackLongTasks`
  * `trackBackgroundEvents`
  * `trackFrustrations`
  * `setVitalsUpdateFrequency`
  * `setSessionListener`
* specific to Android:
  * `trackNonFatalAnrs`
  * `useViewTrackingStrategy`
  * `trackUserInteractions`
* specific to iOS:
  * `trackUiKitViews`
  * `trackUiKitActions`

Platform-specific methods are available only when used from the specific source set.

Platform-specific classes are not re-exposed in the platform-specific source sets, so wrappers around them are implemented with similar naming, but they reside in KMP package.

This API is not final, maybe we will be able to harmonize it a bit more by pulling some platform-specific methods into the common set.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

