### PR TITLE
iOS: Add App Hangs threshold configuration

### DIFF
--- a/features/rum/src/iosMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
+++ b/features/rum/src/iosMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
@@ -51,6 +51,26 @@ fun RumConfiguration.Builder.trackUiKitActions(
     return this
 }
 
+/**
+ * Enables App Hangs monitoring with the given threshold (in milliseconds).
+ *
+ * Only App Hangs that last more than this threshold will be reported. The minimal allowed value for this option is
+ * 100 milliseconds. To disable hangs monitoring, set this parameter to `null`.
+ *
+ * Note: Be cautious when setting the threshold to very small values, as it may lead to excessive reporting of hangs.
+ *       The SDK implements a secondary thread for monitoring App Hangs. To reduce CPU utilization, it tracks hangs
+ *       with a tolerance of 2.5%, meaning that some hangs lasting very close to this threshold may not be reported.
+ *
+ * Note: App Hangs monitoring requires Datadog Crash Reporting to be enabled. Otherwise stack trace will be
+ * not reported in App Hang errors.
+ *
+ * @param thresholdMs App Hangs threshold in milliseconds. Default is `null` (monitoring is disabled).
+ */
+fun RumConfiguration.Builder.setAppHangThreshold(thresholdMs: Long?): RumConfiguration.Builder {
+    nativePlatformBuilder.setAppHangThreshold(thresholdMs)
+    return this
+}
+
 internal actual fun platformConfigurationBuilder(applicationId: String): PlatformRumConfigurationBuilder<Any> =
     IOSRumConfigurationBuilder(applicationId)
 

--- a/features/rum/src/iosMain/kotlin/com/datadog/kmp/rum/configuration/internal/IOSRumConfigurationBuilder.kt
+++ b/features/rum/src/iosMain/kotlin/com/datadog/kmp/rum/configuration/internal/IOSRumConfigurationBuilder.kt
@@ -120,6 +120,15 @@ internal class IOSRumConfigurationBuilder : PlatformRumConfigurationBuilder<DDRU
         nativeConfiguration.setUiKitActionsPredicate(nativePredicate)
     }
 
+    fun setAppHangThreshold(thresholdMs: Long?) {
+        val thresholdSeconds = if (thresholdMs != null) {
+            thresholdMs.toDouble() / MILLISECONDS_IN_SECOND
+        } else {
+            0.0
+        }
+        nativeConfiguration.setAppHangThreshold(thresholdSeconds)
+    }
+
     override fun build(): DDRUMConfiguration {
         return nativeConfiguration
     }

--- a/features/rum/src/iosTest/kotlin/com/datadog/kmp/rum/configuration/internal/IOSRumConfigurationBuilderTest.kt
+++ b/features/rum/src/iosTest/kotlin/com/datadog/kmp/rum/configuration/internal/IOSRumConfigurationBuilderTest.kt
@@ -183,6 +183,27 @@ class IOSRumConfigurationBuilderTest {
     }
 
     @Test
+    fun `M set app hang threshold W setAppHangThreshold`() {
+        // Given
+        val fakeThresholdMs = randomLong(from = 1L)
+
+        // When
+        testedBuilder.setAppHangThreshold(fakeThresholdMs)
+
+        // Then
+        assertEquals(fakeThresholdMs.toDouble(), fakeNativeRumConfiguration.appHangThreshold() * 1000)
+    }
+
+    @Test
+    fun `M disable app hang threshold W setAppHangThreshold + null value`() {
+        // When
+        testedBuilder.setAppHangThreshold(null)
+
+        // Then
+        assertEquals(0.0, fakeNativeRumConfiguration.appHangThreshold())
+    }
+
+    @Test
     fun `M return native configuration W build`() {
         // When
         val nativeConfiguration = testedBuilder.build()

--- a/sample/shared/src/iosMain/kotlin/com/datadog/kmp/sample/Utils.ios.kt
+++ b/sample/shared/src/iosMain/kotlin/com/datadog/kmp/sample/Utils.ios.kt
@@ -7,6 +7,7 @@
 package com.datadog.kmp.sample
 
 import com.datadog.kmp.rum.configuration.RumConfiguration
+import com.datadog.kmp.rum.configuration.setAppHangThreshold
 import com.datadog.kmp.rum.configuration.trackUiKitActions
 import com.datadog.kmp.rum.configuration.trackUiKitViews
 
@@ -14,5 +15,8 @@ internal actual fun platformSpecificSetup(rumConfigurationBuilder: RumConfigurat
     with(rumConfigurationBuilder) {
         trackUiKitViews()
         trackUiKitActions()
+        setAppHangThreshold(APP_HANG_THRESHOLD_MS)
     }
 }
+
+const val APP_HANG_THRESHOLD_MS = 100L


### PR DESCRIPTION
### What does this PR do?

This PR adds the necessary iOS API to configure App Hangs threshold. To be merged after https://github.com/DataDog/dd-sdk-ios/pull/1908 is merged and released (iOS SDK 2.14.0 eventually).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

