### PR TITLE
RUM-5113: Catch and report unhandled Kotlin exceptions

### DIFF
--- a/core/api/commonMain/apiSurface
+++ b/core/api/commonMain/apiSurface
@@ -40,6 +40,8 @@ enum com.datadog.kmp.core.configuration.UploadFrequency
   - FREQUENT
   - AVERAGE
   - RARE
+object com.datadog.kmp.internal.InternalProxy
+  val isCrashReportingEnabled: Boolean
 enum com.datadog.kmp.privacy.TrackingConsent
   - GRANTED
   - NOT_GRANTED

--- a/core/api/iosMain/apiSurface
+++ b/core/api/iosMain/apiSurface
@@ -7,7 +7,11 @@ actual object com.datadog.kmp.Datadog
   actual fun addUserExtraInfo(Map<String, Any?>)
   actual fun clearAllData()
   actual fun stopInstance()
+const val INCLUDE_BINARY_IMAGES: String
+const val RUM_ERROR_IS_CRASH: String
+const val LOG_ERROR_IS_CRASH: String
 fun withIncludeBinaryImages(Map<String, Any?>): Map<String, Any?>
 fun <K, V> eraseKeyType(Map<K, V>): Map<Any?, V>
 fun createNSErrorFromThrowable(Throwable, String? = null): platform.Foundation.NSError
 fun createNSErrorFromMessage(String): platform.Foundation.NSError
+fun addDatadogUnhandledExceptionHook((Throwable) -> Unit)

--- a/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -38,6 +38,9 @@ actual object Datadog {
         get() = DatadogAndroid.getVerbosity().toSdkLogVerbosity
         set(value) = DatadogAndroid.setVerbosity(value.native)
 
+    @Volatile
+    internal actual var isCrashReportingEnabled: Boolean = false
+
     /**
      * Initializes an instance of the Datadog SDK.
      * @param context your application context (applicable only for Android)
@@ -55,6 +58,7 @@ actual object Datadog {
     ) {
         requireNotNull(context)
         DatadogAndroid.initialize(context as Context, configuration.native, trackingConsent.native)
+        isCrashReportingEnabled = configuration.coreConfig.trackCrashes
     }
 
     /**

--- a/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -24,6 +24,8 @@ expect object Datadog {
      */
     var verbosity: SdkLogVerbosity?
 
+    internal var isCrashReportingEnabled: Boolean
+
     /**
      * Initializes an instance of the Datadog SDK.
      * @param context your application context (applicable only for Android)

--- a/core/src/commonMain/kotlin/com/datadog/kmp/internal/InternalProxy.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/internal/InternalProxy.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.internal
+
+import com.datadog.kmp.Datadog
+
+/**
+ * Internal API, can be changed or removed at any point.
+ */
+object InternalProxy {
+
+    /**
+     * Indicates if crash reporting is enabled or not.
+     */
+    val isCrashReportingEnabled: Boolean
+        get() { return Datadog.isCrashReportingEnabled }
+}

--- a/core/src/iosMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/iosMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -30,6 +30,7 @@ import com.datadog.kmp.core.configuration.BatchSize
 import com.datadog.kmp.core.configuration.Configuration
 import com.datadog.kmp.core.configuration.UploadFrequency
 import com.datadog.kmp.privacy.TrackingConsent
+import kotlin.concurrent.Volatile
 import cocoapods.DatadogObjc.DDDatadog as DatadogIOS
 
 /**
@@ -49,6 +50,9 @@ actual object Datadog {
         get() = DatadogIOS.verbosityLevel().toSdkLogVerbosity
         set(value) = DatadogIOS.setVerbosityLevel(value.native)
 
+    @Volatile
+    internal actual var isCrashReportingEnabled: Boolean = false
+
     /**
      * Initializes an instance of the Datadog SDK.
      * @param context your application context (applicable only for Android)
@@ -67,6 +71,7 @@ actual object Datadog {
 
         if (configuration.coreConfig.trackCrashes) {
             DDCrashReporter.enable()
+            isCrashReportingEnabled = true
         }
     }
 

--- a/core/src/iosMain/kotlin/com/datadog/kmp/internal/MapExt.kt
+++ b/core/src/iosMain/kotlin/com/datadog/kmp/internal/MapExt.kt
@@ -6,12 +6,25 @@
 
 package com.datadog.kmp.internal
 
-private const val INCLUDE_BINARY_IMAGES = "_dd.error.include_binary_images"
+/**
+ * Internal flag to include binary images with an error with sent to Datadog.
+ */
+const val INCLUDE_BINARY_IMAGES: String = "_dd.error.include_binary_images"
+
+/**
+ * Internal flag to treat RUM error as crash.
+ */
+const val RUM_ERROR_IS_CRASH: String = "_dd.error.is_crash"
+
+/**
+ * Internal flag to treat Log error as crash.
+ */
+const val LOG_ERROR_IS_CRASH: String = "_dd.error_log.is_crash"
 
 /**
  * Adds an internal flag to include binary images.
  *
- * **NOTE**: This is a part of internal API and shouldn't be used.
+ * **NOTE**: This is a part of internal API and shouldn't be used outside of the SDK classes.
  *
  * @param attributes attributes to process.
  * @return Attributes with a flag to include binary images.
@@ -25,7 +38,7 @@ fun withIncludeBinaryImages(attributes: Map<String, Any?>): Map<String, Any?> {
 /**
  * Removes key type.
  *
- * **NOTE**: This is a part of internal API and shouldn't be used.
+ * **NOTE**: This is a part of internal API and shouldn't be used outside of the SDK classes.
  *
  * @param K key type.
  * @param V value type.

--- a/core/src/iosMain/kotlin/com/datadog/kmp/internal/NSErrorExt.kt
+++ b/core/src/iosMain/kotlin/com/datadog/kmp/internal/NSErrorExt.kt
@@ -18,7 +18,7 @@ import kotlin.experimental.ExperimentalNativeApi
  * Creates instance of [NSError] from a given [Throwable] instance with a provided stacktrace. If there is
  * a custom user message, it will be added to the error as well.
  *
- * **NOTE**: This is a part of internal API and shouldn't be used.
+ * **NOTE**: This is a part of internal API and shouldn't be used outside of the SDK classes.
  *
  * @param throwable [Throwable] instance to create [NSError] from.
  * @param message Optional user-provided message.
@@ -41,7 +41,7 @@ fun createNSErrorFromThrowable(throwable: Throwable, message: String? = null): N
 /**
  * Creates instance of [NSError] with a message attached.
  *
- * **NOTE**: This is a part of internal API and shouldn't be used.
+ * **NOTE**: This is a part of internal API and shouldn't be used outside of the SDK classes.
  *
  * @param message message to attache to the error.
  */

--- a/core/src/iosMain/kotlin/com/datadog/kmp/internal/RuntimeExt.kt
+++ b/core/src/iosMain/kotlin/com/datadog/kmp/internal/RuntimeExt.kt
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.internal
+
+import platform.posix.usleep
+import kotlin.concurrent.AtomicReference
+import kotlin.experimental.ExperimentalNativeApi
+
+/**
+ * Adds a hook with Datadog-specific exception handling by using [setUnhandledExceptionHook].
+ *
+ * **NOTE**: This is a part of internal API and shouldn't be used outside of the SDK classes.
+ *
+ * @param action action to perform when unhandled exception happens.
+ */
+@OptIn(ExperimentalNativeApi::class)
+fun addDatadogUnhandledExceptionHook(action: (Throwable) -> Unit) =
+    addDatadogUnhandledExceptionHookWithTermination(action) {
+        terminateWithUnhandledException(it)
+    }
+
+@OptIn(ExperimentalNativeApi::class)
+internal fun addDatadogUnhandledExceptionHookWithTermination(
+    action: (Throwable) -> Unit,
+    terminateAction: (Throwable) -> Unit
+) {
+    val previousHookHolder = AtomicReference<ReportUnhandledExceptionHook?>(null)
+    val hook = object : ReportUnhandledExceptionHook {
+        override fun invoke(throwable: Throwable) {
+            action.invoke(throwable)
+            previousHookHolder.value?.invoke(throwable)
+            // hook registration order: A -> B -> C
+            // hook processing order: C -> B -> A
+            val canCrash = getUnhandledExceptionHook() == this
+            if (canCrash) {
+                // TODO RUM-5176 RumMonitor.addErrorWithError call is not blocking, so we may have no time to
+                //  write a specific error and we will end up with having a generic runtime crash error. Adding
+                //  a small sleep call here won't hurt: we get better chances that error is written
+                val sleepMicroseconds = 100_000U // 100 ms
+                usleep(sleepMicroseconds)
+
+                // our hook is the last one, we can terminate application, otherwise we shift this
+                // responsibility to other hooks upper in the chain
+                terminateAction(throwable)
+            }
+        }
+    }
+    // in the legacy memory model hook should be frozen, but we are going to ask for Kotlin 2.0.20 as minimum
+    // version, it is using new memory model
+    val previousHook = setUnhandledExceptionHook(hook)
+    previousHookHolder.value = previousHook
+}

--- a/core/src/iosTest/kotlin/com/datadog/kmp/internal/RuntimeExtTest.kt
+++ b/core/src/iosTest/kotlin/com/datadog/kmp/internal/RuntimeExtTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.internal
+
+import com.datadog.tools.random.randomThrowable
+import kotlin.concurrent.AtomicReference
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalNativeApi::class)
+class RuntimeExtTest {
+
+    private var defaultUnhandledExceptionHook: ReportUnhandledExceptionHook? = null
+
+    @BeforeTest
+    fun `set up`() {
+        defaultUnhandledExceptionHook = getUnhandledExceptionHook()
+    }
+
+    @AfterTest
+    fun `tear down`() {
+        setUnhandledExceptionHook(defaultUnhandledExceptionHook)
+    }
+
+    @Test
+    fun `M crash the app W addDatadogUnhandledExceptionHookWithTermination + our hook is the last one`() {
+        // Given
+        val datadogHookA = RecordingAction("A")
+        val datadogHookB = RecordingAction("B")
+        val thirdPartyHook = RecordingAction("ThirdParty")
+        val terminateAction = RecordingAction("Terminate")
+        addDatadogUnhandledExceptionHookWithTermination(datadogHookA, terminateAction)
+        addThirdPartyUnhandledExceptionHook(thirdPartyHook)
+        addDatadogUnhandledExceptionHookWithTermination(datadogHookB, terminateAction)
+        val fakeThrowable = randomThrowable()
+
+        // When
+        getUnhandledExceptionHook()?.invoke(fakeThrowable)
+
+        // Then
+        listOf(datadogHookA, datadogHookB, thirdPartyHook, terminateAction).forEach {
+            assertTrue(it.invoked, "Expected hook=$it to be called, but it wasn't.")
+            assertEquals(1, it.invocationsCount, "Expected hook=$it to be called once, but it wasn't.")
+            assertEquals(
+                fakeThrowable,
+                it.lastInvokedWithThrowable,
+                "Expected hook=$it to be called with throwable=$fakeThrowable," +
+                    " but it was called with ${it.lastInvokedWithThrowable} instead."
+            )
+        }
+    }
+
+    @Test
+    fun `M not crash the app W addDatadogUnhandledExceptionHookWithTermination + our hook is not the last one`() {
+        // Given
+        val datadogHookA = RecordingAction("A")
+        val datadogHookB = RecordingAction("B")
+        val thirdPartyHook = RecordingAction("ThirdParty")
+        val terminateAction = RecordingAction("Terminate")
+        addDatadogUnhandledExceptionHookWithTermination(datadogHookA, terminateAction)
+        addDatadogUnhandledExceptionHookWithTermination(datadogHookB, terminateAction)
+        addThirdPartyUnhandledExceptionHook(thirdPartyHook)
+        val fakeThrowable = randomThrowable()
+
+        // When
+        getUnhandledExceptionHook()?.invoke(fakeThrowable)
+
+        // Then
+        listOf(datadogHookA, datadogHookB, thirdPartyHook).forEach {
+            assertTrue(it.invoked, "Expected hook=$it to be called, but it wasn't.")
+            assertEquals(1, it.invocationsCount, "Expected hook=$it to be called once, but it wasn't.")
+            assertEquals(
+                fakeThrowable,
+                it.lastInvokedWithThrowable,
+                "Expected hook=$it to be called with throwable=$fakeThrowable," +
+                    " but it was called with ${it.lastInvokedWithThrowable} instead."
+            )
+        }
+
+        assertFalse(terminateAction.invoked, "Expected termination action to not be called, but it was.")
+    }
+
+    // region private
+
+    private fun addThirdPartyUnhandledExceptionHook(hook: (Throwable) -> Unit) {
+        // imitates some third-party wrap logic where previous hook is respected
+        val previousHookReference = AtomicReference<ReportUnhandledExceptionHook?>(null)
+        previousHookReference.value = setUnhandledExceptionHook {
+            hook.invoke(it)
+            previousHookReference.value?.invoke(it)
+        }
+    }
+
+    private data class RecordingAction(
+        val name: String,
+        var invoked: Boolean = false,
+        var invocationsCount: Int = 0,
+        var lastInvokedWithThrowable: Throwable? = null
+    ) : (Throwable) -> Unit {
+
+        override fun invoke(throwable: Throwable) {
+            invoked = true
+            invocationsCount++
+            lastInvokedWithThrowable = throwable
+        }
+    }
+
+    // endregion
+}

--- a/features/logs/src/iosMain/kotlin/com/datadog/kmp/log/Logs.kt
+++ b/features/logs/src/iosMain/kotlin/com/datadog/kmp/log/Logs.kt
@@ -6,13 +6,23 @@
 
 package com.datadog.kmp.log
 
+import cocoapods.DatadogObjc.DDLogger
+import cocoapods.DatadogObjc.DDLoggerConfiguration
 import cocoapods.DatadogObjc.DDLogs
 import cocoapods.DatadogObjc.DDLogsConfiguration
+import com.datadog.kmp.internal.INCLUDE_BINARY_IMAGES
+import com.datadog.kmp.internal.InternalProxy
+import com.datadog.kmp.internal.LOG_ERROR_IS_CRASH
+import com.datadog.kmp.internal.addDatadogUnhandledExceptionHook
+import com.datadog.kmp.internal.createNSErrorFromThrowable
+import com.datadog.kmp.log.internal.default
 
 /**
  * An entry point to Datadog Logs feature.
  */
 actual object Logs {
+
+    private const val ALL_IN_SAMPLE_RATE = 100f
 
     /**
      * Enables a Logs feature.
@@ -21,6 +31,26 @@ actual object Logs {
         DDLogs.enableWith(
             DDLogsConfiguration(customEndpoint = null)
         )
+
+        if (InternalProxy.isCrashReportingEnabled) {
+            addDatadogUnhandledExceptionHook {
+                val loggerConfiguration = DDLoggerConfiguration.default().apply {
+                    setNetworkInfoEnabled(true)
+                    setRemoteSampleRate(ALL_IN_SAMPLE_RATE)
+                }
+                // TODO RUM-5178 No ObjC API to write crash log directly, without any logger
+                val crashLogger = DDLogger.createWith(loggerConfiguration)
+
+                crashLogger.critical(
+                    "Caught unhandled Kotlin exception",
+                    createNSErrorFromThrowable(it),
+                    mutableMapOf<Any?, Any?>().apply {
+                        this += INCLUDE_BINARY_IMAGES to true
+                        this += LOG_ERROR_IS_CRASH to true
+                    }
+                )
+            }
+        }
     }
 
     /**

--- a/features/rum/src/iosMain/kotlin/com/datadog/kmp/rum/Rum.kt
+++ b/features/rum/src/iosMain/kotlin/com/datadog/kmp/rum/Rum.kt
@@ -8,12 +8,20 @@ package com.datadog.kmp.rum
 
 import cocoapods.DatadogObjc.DDRUM
 import cocoapods.DatadogObjc.DDRUMConfiguration
+import cocoapods.DatadogObjc.DDRUMErrorSourceSource
+import cocoapods.DatadogObjc.DDRUMMonitor
+import com.datadog.kmp.internal.INCLUDE_BINARY_IMAGES
+import com.datadog.kmp.internal.InternalProxy
+import com.datadog.kmp.internal.RUM_ERROR_IS_CRASH
+import com.datadog.kmp.internal.addDatadogUnhandledExceptionHook
+import com.datadog.kmp.internal.createNSErrorFromThrowable
 import com.datadog.kmp.rum.configuration.RumConfiguration
 
 /**
  * An entry point to Datadog RUM feature.
  */
 actual object Rum {
+
     /**
      * Enables a RUM feature based on the configuration provided and registers RUM monitor.
      *
@@ -21,5 +29,23 @@ actual object Rum {
      */
     actual fun enable(rumConfiguration: RumConfiguration) {
         DDRUM.enableWith(rumConfiguration.nativeConfiguration as DDRUMConfiguration)
+
+        if (InternalProxy.isCrashReportingEnabled) {
+            addDatadogUnhandledExceptionHook {
+                DDRUMMonitor.shared()
+                    .addErrorWithError(
+                        createNSErrorFromThrowable(it),
+                        DDRUMErrorSourceSource,
+                        mutableMapOf<Any?, Any?>().apply {
+                            this += INCLUDE_BINARY_IMAGES to true
+                            // we always assume that if this hook is called - then it is a crash. Our own hook
+                            // implementation will crash app if it is top-most hook, and if it is not, then it is
+                            // responsibility of the hooks upper in the chain. If they don't crash the app - they
+                            // should, their fault.
+                            this += RUM_ERROR_IS_CRASH to true
+                        }
+                    )
+            }
+        }
     }
 }

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
@@ -60,7 +60,13 @@ fun initDatadog(context: Any? = null) {
     Datadog.setUserInfo(
         name = "Random User",
         email = "user@example.com",
-        extraInfo = mapOf("age" to 42, "location" to "universe", "null-attribute" to null)
+        extraInfo = mapOf(
+            "age" to 42,
+            "location" to "universe",
+            "boolean-attribute" to true,
+            "null-attribute" to null,
+            "boolean-attribute" to true
+        )
     )
 }
 
@@ -92,7 +98,11 @@ fun trackView(viewName: String) {
     RumMonitor.get().startView(
         viewName,
         viewName,
-        mapOf("custom-view-attribute" to "view-attribute-value", "nullable-view-attribute" to null)
+        mapOf(
+            "custom-view-attribute" to "view-attribute-value",
+            "boolean-view-attribute" to true,
+            "nullable-view-attribute" to null
+        )
     )
 }
 
@@ -100,7 +110,11 @@ fun trackAction(actionName: String) {
     RumMonitor.get().addAction(
         RumActionType.TAP,
         actionName,
-        mapOf("custom-action-attribute" to "action-attribute-value", "nullable-action-attribute" to null)
+        mapOf(
+            "custom-action-attribute" to "action-attribute-value",
+            "boolean-action-attribute" to true,
+            "nullable-action-attribute" to null
+        )
     )
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds support of reporting unhandled KMP exceptions. They exist because in Swift there is no concept of unchecked exceptions, so if any Kotlin code throws to Swift, it should have `@Throws` annotation. If exception is not handled, then it is reported to what is set in `unhandledExceptionHook` and then application should be terminated.

If this hook is not implemented, we will still catch crash, but it will be less precise or may even miss the relevant information.

This PR will report such exceptions to Logs and RUM if crash reporting is enabled.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

