### PR TITLE
Fix version reference for pods

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
     cocoapods {
         // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
         // so what is below for podspec description is just a fake thing to make tooling happy
-        version = AndroidConfig.VERSION.toString()
+        version = AndroidConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
         name = "DatadogKMPCore"

--- a/features/logs/build.gradle.kts
+++ b/features/logs/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
     cocoapods {
         // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
         // so what is below for podspec description is just a fake thing to make tooling happy
-        version = AndroidConfig.VERSION.toString()
+        version = AndroidConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
         name = "DatadogKMPLogs"

--- a/features/rum/build.gradle.kts
+++ b/features/rum/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
     cocoapods {
         // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
         // so what is below for podspec description is just a fake thing to make tooling happy
-        version = AndroidConfig.VERSION.toString()
+        version = AndroidConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
         name = "DatadogKMPRUM"

--- a/features/webview/build.gradle.kts
+++ b/features/webview/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
     cocoapods {
         // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
         // so what is below for podspec description is just a fake thing to make tooling happy
-        version = AndroidConfig.VERSION.toString()
+        version = AndroidConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
         name = "DatadogKMPWebView"


### PR DESCRIPTION
### What does this PR do?

This PR fixes the conversion of `AndroidConfig.VERSION` reference to the semver string.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

