### PR TITLE
Update Datadog iOS SDK to version 2.14.1

### DIFF
--- a/features/rum/api/iosMain/apiSurface
+++ b/features/rum/api/iosMain/apiSurface
@@ -6,6 +6,7 @@ fun RumMonitor.stopResourceWithError(String, String, platform.Foundation.NSURLRe
 fun RumMonitor.addError(RumErrorSource, platform.Foundation.NSError, Map<String, Any?>)
 fun RumConfiguration.Builder.trackUiKitViews(com.datadog.kmp.rum.tracking.UIKitRUMViewsPredicate = DefaultUIKitRUMViewsPredicate()): RumConfiguration.Builder
 fun RumConfiguration.Builder.trackUiKitActions(com.datadog.kmp.rum.tracking.UIKitRUMActionsPredicate = DefaultUIKitRUMActionsPredicate()): RumConfiguration.Builder
+fun RumConfiguration.Builder.setAppHangThreshold(Long?): RumConfiguration.Builder
 interface com.datadog.kmp.rum.internal.AdvancedRumNetworkMonitor
   fun addResourceMetrics(String, platform.Foundation.NSURLSessionTaskMetrics, Map<String, Any?>)
 class com.datadog.kmp.rum.tracking.DefaultUIKitRUMActionsPredicate : UIKitRUMActionsPredicate

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ androidx-navigation-forSdk = "2.3.0"
 androidx-navigation-forApp = "2.7.7"
 androidx-activityCompose = "1.8.0"
 datadog-android = "2.11.0"
-datadog-ios = "2.14.0"
+datadog-ios = "2.14.1"
 dependencyLicense = "0.2"
 kotlinGrammarParser = "0.1.0"
 

--- a/sample/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/sample/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -11,9 +11,9 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
-		F648469C2C37FB8F000AC3A0 /* DatadogObjc in Frameworks */ = {isa = PBXBuildFile; productRef = F648469B2C37FB8F000AC3A0 /* DatadogObjc */; };
-		F648469E2C37FB94000AC3A0 /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = F648469D2C37FB94000AC3A0 /* DatadogCrashReporting */; };
-		F64846A02C37FB98000AC3A0 /* DatadogWebViewTracking in Frameworks */ = {isa = PBXBuildFile; productRef = F648469F2C37FB98000AC3A0 /* DatadogWebViewTracking */; };
+		F64846B82C3DA0F5000AC3A0 /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = F64846B72C3DA0F5000AC3A0 /* DatadogCrashReporting */; };
+		F64846BA2C3DA0F5000AC3A0 /* DatadogObjc in Frameworks */ = {isa = PBXBuildFile; productRef = F64846B92C3DA0F5000AC3A0 /* DatadogObjc */; };
+		F64846BC2C3DA0F5000AC3A0 /* DatadogWebViewTracking in Frameworks */ = {isa = PBXBuildFile; productRef = F64846BB2C3DA0F5000AC3A0 /* DatadogWebViewTracking */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -43,9 +43,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F64846A02C37FB98000AC3A0 /* DatadogWebViewTracking in Frameworks */,
-				F648469E2C37FB94000AC3A0 /* DatadogCrashReporting in Frameworks */,
-				F648469C2C37FB8F000AC3A0 /* DatadogObjc in Frameworks */,
+				F64846BC2C3DA0F5000AC3A0 /* DatadogWebViewTracking in Frameworks */,
+				F64846B82C3DA0F5000AC3A0 /* DatadogCrashReporting in Frameworks */,
+				F64846BA2C3DA0F5000AC3A0 /* DatadogObjc in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,9 +115,9 @@
 			);
 			name = iosApp;
 			packageProductDependencies = (
-				F648469B2C37FB8F000AC3A0 /* DatadogObjc */,
-				F648469D2C37FB94000AC3A0 /* DatadogCrashReporting */,
-				F648469F2C37FB98000AC3A0 /* DatadogWebViewTracking */,
+				F64846B72C3DA0F5000AC3A0 /* DatadogCrashReporting */,
+				F64846B92C3DA0F5000AC3A0 /* DatadogObjc */,
+				F64846BB2C3DA0F5000AC3A0 /* DatadogWebViewTracking */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* iosApp.app */;
@@ -148,7 +148,7 @@
 			);
 			mainGroup = 7555FF72242A565900829871;
 			packageReferences = (
-				F648469A2C37FB5B000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */,
+				F64846B62C3DA0F5000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -402,30 +402,30 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		F648469A2C37FB5B000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */ = {
+		F64846B62C3DA0F5000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DataDog/dd-sdk-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 2.14.0;
+				version = 2.14.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F648469B2C37FB8F000AC3A0 /* DatadogObjc */ = {
+		F64846B72C3DA0F5000AC3A0 /* DatadogCrashReporting */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F648469A2C37FB5B000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
-			productName = DatadogObjc;
-		};
-		F648469D2C37FB94000AC3A0 /* DatadogCrashReporting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F648469A2C37FB5B000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
+			package = F64846B62C3DA0F5000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
 			productName = DatadogCrashReporting;
 		};
-		F648469F2C37FB98000AC3A0 /* DatadogWebViewTracking */ = {
+		F64846B92C3DA0F5000AC3A0 /* DatadogObjc */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F648469A2C37FB5B000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
+			package = F64846B62C3DA0F5000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
+			productName = DatadogObjc;
+		};
+		F64846BB2C3DA0F5000AC3A0 /* DatadogWebViewTracking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F64846B62C3DA0F5000AC3A0 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
 			productName = DatadogWebViewTracking;
 		};
 /* End XCSwiftPackageProductDependency section */


### PR DESCRIPTION
### What does this PR do?

This PR updates Datadog iOS SDK to version 2.14.1.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

