### PR TITLE
Change sleep time during unhandled exception handling

### DIFF
--- a/core/src/iosMain/kotlin/com/datadog/kmp/internal/RuntimeExt.kt
+++ b/core/src/iosMain/kotlin/com/datadog/kmp/internal/RuntimeExt.kt
@@ -40,7 +40,7 @@ internal fun addDatadogUnhandledExceptionHookWithTermination(
                 // TODO RUM-5176 RumMonitor.addErrorWithError call is not blocking, so we may have no time to
                 //  write a specific error and we will end up with having a generic runtime crash error. Adding
                 //  a small sleep call here won't hurt: we get better chances that error is written
-                val sleepMicroseconds = 100_000U // 100 ms
+                val sleepMicroseconds = 80_000U // 80 ms
                 usleep(sleepMicroseconds)
 
                 // our hook is the last one, we can terminate application, otherwise we shift this


### PR DESCRIPTION
### What does this PR do?

This PR changes the sleep duration during unhandled exception handling to avoid having app hang reported (which has 100ms threshold by default).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

