### PR TITLE
RUM-5319: Set Sonatype staging repository description

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.datadog.build.ProjectConfig
+import com.datadog.build.utils.taskConfig
+import io.github.gradlenexus.publishplugin.AbstractNexusStagingRepositoryTask
+
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
@@ -15,6 +19,8 @@ plugins {
     alias(libs.plugins.mokkery) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.nexusPublish)
+    // false - just to load classes into a classpath
+    id("datadog-build-config") apply false
 }
 
 nexusPublishing {
@@ -27,6 +33,14 @@ nexusPublishing {
             if (sonatypePassword != null) password.set(sonatypePassword)
         }
     }
+}
+
+// nexus-publish plugin creates repository tasks only for the root project, so we cannot set a
+// sub-project-specific description
+project.taskConfig<AbstractNexusStagingRepositoryTask> {
+    repositoryDescription.set(
+        "${ProjectConfig.GROUP_ID}:dd-sdk-kotlin-multiplatform:${ProjectConfig.VERSION.name}"
+    )
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

This should set the following field propertly

![image](https://github.com/DataDog/dd-sdk-kotlin-multiplatform/assets/4046447/ce8fea5e-ea6d-44bb-818a-143745ff3d20)

I didn't test it. If everything is fine, the same should be done in Android SDK repo.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

