### PR TITLE
Make published Apple modules non-static frameworks

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 }
 
 kotlin {
+
     cocoapods {
         // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
         // so what is below for podspec description is just a fake thing to make tooling happy
@@ -33,14 +34,6 @@ kotlin {
 
         framework {
             baseName = "DatadogKMPCore"
-        }
-
-        targets.all {
-            if (this is KotlinNativeTarget && konanTarget.family.isAppleFamily) {
-                compilations.getByName("main") {
-                    cinterops.create("DDBinaryImages")
-                }
-            }
         }
 
         val compilerOptionFlag = "-compiler-option"
@@ -66,6 +59,14 @@ kotlin {
                 compilerOptionFlag,
                 "-fmodules"
             )
+        }
+    }
+
+    targets.all {
+        if (this is KotlinNativeTarget && konanTarget.family.isAppleFamily) {
+            compilations.getByName("main") {
+                cinterops.create("DDBinaryImages")
+            }
         }
     }
 

--- a/features/logs/build.gradle.kts
+++ b/features/logs/build.gradle.kts
@@ -35,7 +35,6 @@ kotlin {
 
         framework {
             baseName = "DatadogKMPLogs"
-            isStatic = true
         }
 
         // need to link it only for the tests so far (maybe this will change

--- a/features/rum/build.gradle.kts
+++ b/features/rum/build.gradle.kts
@@ -35,7 +35,6 @@ kotlin {
 
         framework {
             baseName = "DatadogKMPRUM"
-            isStatic = true
         }
 
         // need to link it only for the tests so far (maybe this will change

--- a/features/webview/build.gradle.kts
+++ b/features/webview/build.gradle.kts
@@ -37,7 +37,6 @@ kotlin {
 
         framework {
             baseName = "DatadogKMPWebView"
-            isStatic = true
         }
 
         // need to link it only for the tests so far (maybe this will change

--- a/integrations/ktor/build.gradle.kts
+++ b/integrations/ktor/build.gradle.kts
@@ -35,7 +35,6 @@ kotlin {
 
         framework {
             baseName = "DatadogKMPKtor"
-            isStatic = true
         }
 
         // need to link it only for the tests so far (maybe this will change


### PR DESCRIPTION
### What does this PR do?

This property is actually useless, because these modules are consumed through the shared library and not directly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

