### PR TITLE
Provide fallback values for enums in case of native -> common models conversion

### DIFF
--- a/features/rum/build.gradle.kts
+++ b/features/rum/build.gradle.kts
@@ -120,6 +120,21 @@ datadogBuildConfig {
     pomDescription = "The RUM feature to use with the Datadog monitoring library for Kotlin Multiplatform."
 }
 
+@Suppress("PropertyName", "VariableNaming")
+val VIEW_EVENT_MODEL_NAME = "ViewEvent"
+
+@Suppress("PropertyName", "VariableNaming")
+val ACTION_EVENT_MODEL_NAME = "ActionEvent"
+
+@Suppress("PropertyName", "VariableNaming")
+val ERROR_EVENT_MODEL_NAME = "ErrorEvent"
+
+@Suppress("PropertyName", "VariableNaming")
+val RESOURCE_EVENT_MODEL_NAME = "ResourceEvent"
+
+@Suppress("PropertyName", "VariableNaming")
+val LONG_TASK_EVENT_MODEL_NAME = "LongTaskEvent"
+
 jsonSchemaGenerator {
     schema("rum") {
         location = SchemaLocation.Git(
@@ -137,16 +152,59 @@ jsonSchemaGenerator {
             "vital-schema.json"
         )
         inputNameMapping = mapOf(
-            "action-schema.json" to "ActionEvent",
-            "error-schema.json" to "ErrorEvent",
-            "resource-schema.json" to "ResourceEvent",
-            "view-schema.json" to "ViewEvent",
-            "long_task-schema.json" to "LongTaskEvent"
+            "action-schema.json" to ACTION_EVENT_MODEL_NAME,
+            "error-schema.json" to ERROR_EVENT_MODEL_NAME,
+            "resource-schema.json" to RESOURCE_EVENT_MODEL_NAME,
+            "view-schema.json" to VIEW_EVENT_MODEL_NAME,
+            "long_task-schema.json" to LONG_TASK_EVENT_MODEL_NAME
         )
+
+        @Suppress("StringLiteralDuplication")
+        val defaultEnumValues = mapOf(
+            "$VIEW_EVENT_MODEL_NAME.${VIEW_EVENT_MODEL_NAME}SessionType" to "USER",
+            "$VIEW_EVENT_MODEL_NAME.Status" to "CONNECTED",
+            "$VIEW_EVENT_MODEL_NAME.EffectiveType" to "`4G`",
+            "$VIEW_EVENT_MODEL_NAME.DeviceType" to "OTHER",
+            "$VIEW_EVENT_MODEL_NAME.ReplayLevel" to "MASK_USER_INPUT",
+            "$VIEW_EVENT_MODEL_NAME.Plan" to "PLAN_1",
+            "$VIEW_EVENT_MODEL_NAME.SessionPrecondition" to "USER_APP_LAUNCH",
+            "$VIEW_EVENT_MODEL_NAME.State" to "ACTIVE",
+            "$ACTION_EVENT_MODEL_NAME.${ACTION_EVENT_MODEL_NAME}ActionType" to "TAP",
+            "$RESOURCE_EVENT_MODEL_NAME.ResourceType" to "OTHER",
+            "$RESOURCE_EVENT_MODEL_NAME.OperationType" to "QUERY",
+            "$RESOURCE_EVENT_MODEL_NAME.Method" to "GET",
+            "$RESOURCE_EVENT_MODEL_NAME.ProviderType" to "OTHER",
+            "$ERROR_EVENT_MODEL_NAME.ErrorSource" to "CUSTOM",
+            "$ERROR_EVENT_MODEL_NAME.Category" to "EXCEPTION",
+            "$ERROR_EVENT_MODEL_NAME.Handling" to "UNHANDLED"
+        )
+
+        val commonizeDefaultEnumValues: (Map<String, String>) -> Map<String, String> = {
+            it.toMutableMap()
+                .apply {
+                    val add = entries.flatMap {
+                        listOf(
+                            it.key.replace(VIEW_EVENT_MODEL_NAME, ACTION_EVENT_MODEL_NAME) to it.value,
+                            it.key.replace(VIEW_EVENT_MODEL_NAME, RESOURCE_EVENT_MODEL_NAME) to it.value,
+                            it.key.replace(VIEW_EVENT_MODEL_NAME, ERROR_EVENT_MODEL_NAME) to it.value,
+                            it.key.replace(VIEW_EVENT_MODEL_NAME, LONG_TASK_EVENT_MODEL_NAME) to it.value,
+                            it.key.replace(RESOURCE_EVENT_MODEL_NAME, ERROR_EVENT_MODEL_NAME) to it.value
+                        )
+                    }
+                    putAll(add)
+                }
+        }
 
         androidModelsMappingGeneration {
             enabled = true
             androidModelsPackageName = "com.datadog.android.rum.model"
+            defaultCommonEnumValues = commonizeDefaultEnumValues(
+                defaultEnumValues + mapOf(
+                    "$VIEW_EVENT_MODEL_NAME.${VIEW_EVENT_MODEL_NAME}Source" to "ANDROID",
+                    "$VIEW_EVENT_MODEL_NAME.LoadingType" to "ACTIVITY_DISPLAY",
+                    "$ERROR_EVENT_MODEL_NAME.SourceType" to "ANDROID"
+                )
+            )
         }
 
         iosModelsMappingGeneration {
@@ -164,6 +222,13 @@ jsonSchemaGenerator {
                 "Device" to "RUMDevice",
                 "OS" to "RUMOperatingSystem",
                 "SessionPrecondition" to "RUMSessionPrecondition"
+            )
+            defaultCommonEnumValues = commonizeDefaultEnumValues(
+                defaultEnumValues + mapOf(
+                    "$VIEW_EVENT_MODEL_NAME.${VIEW_EVENT_MODEL_NAME}Source" to "IOS",
+                    "$VIEW_EVENT_MODEL_NAME.LoadingType" to "VIEW_CONTROLLER_DISPLAY",
+                    "$ERROR_EVENT_MODEL_NAME.SourceType" to "IOS"
+                )
             )
         }
     }

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/GenerateJsonSchemaExtension.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/GenerateJsonSchemaExtension.kt
@@ -62,6 +62,7 @@ abstract class JsonSchema @Inject constructor(
 interface AndroidModelsMappingGeneration {
     val enabled: Property<Boolean>
     val androidModelsPackageName: Property<String>
+    val defaultCommonEnumValues: MapProperty<String, String>
 }
 
 interface IOSModelsMappingGeneration {
@@ -69,6 +70,7 @@ interface IOSModelsMappingGeneration {
     val iosModelsPackageName: Property<String>
     val iosModelsClassNamePrefix: Property<String>
     val typeNameRemapping: MapProperty<String, String>
+    val defaultCommonEnumValues: MapProperty<String, String>
 }
 
 sealed class SchemaLocation {

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/GenerateJsonSchemaTask.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/GenerateJsonSchemaTask.kt
@@ -144,6 +144,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
                         File(outputDir.path.replace("commonMain", "androidMain")),
                         commonModelsPackageName = targetPackageName,
                         androidModelsPackageName = androidModelsPackageName.get(),
+                        defaultCommonEnumValues = defaultCommonEnumValues.get(),
                         logger
                     )
                     mappingGenerator.generate(type)
@@ -157,6 +158,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
                         iosModelsPackageName = iosModelsPackageName.get(),
                         iosModelsClassNamePrefix = iosModelsClassNamePrefix.getOrElse(""),
                         typeNameRemapping = typeNameRemapping.get(),
+                        defaultCommonEnumValues = defaultCommonEnumValues.get(),
                         logger
                     )
                     mappingGenerator.generate(type)

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/generator/AndroidModelsMappingFileGenerator.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/generator/AndroidModelsMappingFileGenerator.kt
@@ -22,6 +22,7 @@ internal class AndroidModelsMappingFileGenerator(
     private val outputDir: File,
     commonModelsPackageName: String,
     private val androidModelsPackageName: String,
+    private val defaultCommonEnumValues: Map<String, String>,
     private val logger: Logger
 ) : NativeModelsMappingFileGenerator(commonModelsPackageName, mutableSetOf()) {
 
@@ -209,6 +210,19 @@ internal class AndroidModelsMappingFileGenerator(
                                     )
                                 }
                             }
+                            // we need to provide default fallback values for enum conversion, because even though
+                            // generated code covers all enum values, these are values for the specific
+                            // native SDK version. It can be the case that final application has a newer native SDK
+                            // version will enum values not known by KMP SDK.
+                            val defaultEnumValue = defaultCommonEnumValues[fullCommonEnumName]
+                                ?: throw IllegalStateException(
+                                    "Default value for enum type $fullCommonEnumName is not provided"
+                                )
+                            addStatement(
+                                "else -> %T.%N",
+                                returnClass,
+                                defaultEnumValue
+                            )
                         }
                         .endControlFlow()
                         .build()

--- a/tools/build-plugins/src/test/kotlin/com/datadog/build/plugin/jsonschema/generator/AndroidModelsMappingFileGeneratorTest.kt
+++ b/tools/build-plugins/src/test/kotlin/com/datadog/build/plugin/jsonschema/generator/AndroidModelsMappingFileGeneratorTest.kt
@@ -7,6 +7,18 @@ class AndroidModelsMappingFileGeneratorTest : NativeModelsMappingFileGeneratorTe
             outputDir = tempDir,
             commonModelsPackageName = COMMON_MODELS_PACKAGE_NAME,
             androidModelsPackageName = "com.datadog.android.rum.model",
+            defaultCommonEnumValues = mapOf(
+                "ViewEvent.ViewEventSessionType" to "USER",
+                "ViewEvent.Status" to "CONNECTED",
+                "ViewEvent.EffectiveType" to "`4G`",
+                "ViewEvent.DeviceType" to "OTHER",
+                "ViewEvent.ReplayLevel" to "MASK_USER_INPUT",
+                "ViewEvent.Plan" to "PLAN_1",
+                "ViewEvent.SessionPrecondition" to "USER_APP_LAUNCH",
+                "ViewEvent.State" to "ACTIVE",
+                "ViewEvent.ViewEventSource" to "ANDROID",
+                "ViewEvent.LoadingType" to "ACTIVITY_DISPLAY"
+            ),
             logger = mockLogger
         )
     }

--- a/tools/build-plugins/src/test/kotlin/com/datadog/build/plugin/jsonschema/generator/IOSModelsMappingFileGeneratorTest.kt
+++ b/tools/build-plugins/src/test/kotlin/com/datadog/build/plugin/jsonschema/generator/IOSModelsMappingFileGeneratorTest.kt
@@ -20,6 +20,18 @@ class IOSModelsMappingFileGeneratorTest : NativeModelsMappingFileGeneratorTest()
                 "OS" to "RUMOperatingSystem",
                 "SessionPrecondition" to "RUMSessionPrecondition"
             ),
+            defaultCommonEnumValues = mapOf(
+                "ViewEvent.ViewEventSessionType" to "USER",
+                "ViewEvent.Status" to "CONNECTED",
+                "ViewEvent.EffectiveType" to "`4G`",
+                "ViewEvent.DeviceType" to "OTHER",
+                "ViewEvent.ReplayLevel" to "MASK_USER_INPUT",
+                "ViewEvent.Plan" to "PLAN_1",
+                "ViewEvent.SessionPrecondition" to "USER_APP_LAUNCH",
+                "ViewEvent.State" to "ACTIVE",
+                "ViewEvent.ViewEventSource" to "IOS",
+                "ViewEvent.LoadingType" to "VIEW_CONTROLLER_DISPLAY"
+            ),
             logger = mockLogger
         )
     }

--- a/tools/build-plugins/src/test/resources/AndroidViewEventMappingExt.kt
+++ b/tools/build-plugins/src/test/resources/AndroidViewEventMappingExt.kt
@@ -53,6 +53,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventSessionType
       ViewEvent.ViewEventSessionType.SYNTHETICS
   com.datadog.android.rum.model.ViewEvent.ViewEventSessionType.CI_TEST ->
       ViewEvent.ViewEventSessionType.CI_TEST
+  else -> ViewEvent.ViewEventSessionType.USER
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventSource.toCommonEnum():
@@ -70,6 +71,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventSource.toCo
   com.datadog.android.rum.model.ViewEvent.ViewEventSource.UNITY -> ViewEvent.ViewEventSource.UNITY
   com.datadog.android.rum.model.ViewEvent.ViewEventSource.KOTLIN_MULTIPLATFORM ->
       ViewEvent.ViewEventSource.KOTLIN_MULTIPLATFORM
+  else -> ViewEvent.ViewEventSource.ANDROID
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventView.toCommonModel():
@@ -136,6 +138,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.LoadingType.toCommon
       ViewEvent.LoadingType.VIEW_CONTROLLER_DISPLAY
   com.datadog.android.rum.model.ViewEvent.LoadingType.VIEW_CONTROLLER_REDISPLAY ->
       ViewEvent.LoadingType.VIEW_CONTROLLER_REDISPLAY
+  else -> ViewEvent.LoadingType.ACTIVITY_DISPLAY
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.CustomTimings.toCommonModel():
@@ -212,6 +215,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.Status.toCommonEnum(
   com.datadog.android.rum.model.ViewEvent.Status.CONNECTED -> ViewEvent.Status.CONNECTED
   com.datadog.android.rum.model.ViewEvent.Status.NOT_CONNECTED -> ViewEvent.Status.NOT_CONNECTED
   com.datadog.android.rum.model.ViewEvent.Status.MAYBE -> ViewEvent.Status.MAYBE
+  else -> ViewEvent.Status.CONNECTED
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.EffectiveType.toCommonEnum():
@@ -220,6 +224,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.EffectiveType.toComm
   com.datadog.android.rum.model.ViewEvent.EffectiveType.`2G` -> ViewEvent.EffectiveType.`2G`
   com.datadog.android.rum.model.ViewEvent.EffectiveType.`3G` -> ViewEvent.EffectiveType.`3G`
   com.datadog.android.rum.model.ViewEvent.EffectiveType.`4G` -> ViewEvent.EffectiveType.`4G`
+  else -> ViewEvent.EffectiveType.`4G`
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.Cellular.toCommonModel():
@@ -287,6 +292,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.DeviceType.toCommonE
       ViewEvent.DeviceType.GAMING_CONSOLE
   com.datadog.android.rum.model.ViewEvent.DeviceType.BOT -> ViewEvent.DeviceType.BOT
   com.datadog.android.rum.model.ViewEvent.DeviceType.OTHER -> ViewEvent.DeviceType.OTHER
+  else -> ViewEvent.DeviceType.OTHER
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.Dd.toCommonModel(): ViewEvent.Dd =
@@ -309,6 +315,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.Plan.toCommonEnum():
     when(this) {
   com.datadog.android.rum.model.ViewEvent.Plan.PLAN_1 -> ViewEvent.Plan.PLAN_1
   com.datadog.android.rum.model.ViewEvent.Plan.PLAN_2 -> ViewEvent.Plan.PLAN_2
+  else -> ViewEvent.Plan.PLAN_1
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.SessionPrecondition.toCommonEnum():
@@ -327,6 +334,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.SessionPrecondition.
       ViewEvent.SessionPrecondition.FROM_NON_INTERACTIVE_SESSION
   com.datadog.android.rum.model.ViewEvent.SessionPrecondition.EXPLICIT_STOP ->
       ViewEvent.SessionPrecondition.EXPLICIT_STOP
+  else -> ViewEvent.SessionPrecondition.USER_APP_LAUNCH
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.Configuration.toCommonModel():
@@ -349,6 +357,7 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.State.toCommonEnum()
   com.datadog.android.rum.model.ViewEvent.State.HIDDEN -> ViewEvent.State.HIDDEN
   com.datadog.android.rum.model.ViewEvent.State.FROZEN -> ViewEvent.State.FROZEN
   com.datadog.android.rum.model.ViewEvent.State.TERMINATED -> ViewEvent.State.TERMINATED
+  else -> ViewEvent.State.ACTIVE
 }
 
 internal inline fun com.datadog.android.rum.model.ViewEvent.ReplayStats.toCommonModel():
@@ -385,5 +394,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.ReplayLevel.toCommon
   com.datadog.android.rum.model.ViewEvent.ReplayLevel.MASK -> ViewEvent.ReplayLevel.MASK
   com.datadog.android.rum.model.ViewEvent.ReplayLevel.MASK_USER_INPUT ->
       ViewEvent.ReplayLevel.MASK_USER_INPUT
+  else -> ViewEvent.ReplayLevel.MASK_USER_INPUT
 }
 

--- a/tools/build-plugins/src/test/resources/IOSViewEventMappingExt.kt
+++ b/tools/build-plugins/src/test/resources/IOSViewEventMappingExt.kt
@@ -114,7 +114,7 @@ import cocoapods.DatadogObjc.DDRUMViewEventViewResource
 import kotlin.Suppress
 import platform.Foundation.NSNumber
 
-internal inline fun DDRUMViewEvent.toCommonModel(): ViewEvent = ViewEvent(
+internal fun DDRUMViewEvent.toCommonModel(): ViewEvent = ViewEvent(
   date = date().longValue,
   application = application().toCommonModel(),
   service = service(),
@@ -138,12 +138,12 @@ internal inline fun DDRUMViewEvent.toCommonModel(): ViewEvent = ViewEvent(
   privacy = privacy()?.toCommonModel(),
 )
 
-internal inline fun DDRUMViewEventApplication.toCommonModel(): ViewEvent.Application =
+internal fun DDRUMViewEventApplication.toCommonModel(): ViewEvent.Application =
     ViewEvent.Application(
   id = id(),
 )
 
-internal inline fun DDRUMViewEventSession.toCommonModel(): ViewEvent.ViewEventSession =
+internal fun DDRUMViewEventSession.toCommonModel(): ViewEvent.ViewEventSession =
     ViewEvent.ViewEventSession(
   id = id(),
   type = viewEventSessionRUMSessionTypeToCommonEnum(type()),
@@ -152,16 +152,16 @@ internal inline fun DDRUMViewEventSession.toCommonModel(): ViewEvent.ViewEventSe
   sampledForReplay = sampledForReplay()?.boolValue,
 )
 
-internal inline
+internal
     fun viewEventSessionRUMSessionTypeToCommonEnum(enumValue: DDRUMViewEventSessionRUMSessionType):
     ViewEvent.ViewEventSessionType = when(enumValue) {
   DDRUMViewEventSessionRUMSessionTypeUser -> ViewEvent.ViewEventSessionType.USER
   DDRUMViewEventSessionRUMSessionTypeSynthetics -> ViewEvent.ViewEventSessionType.SYNTHETICS
   DDRUMViewEventSessionRUMSessionTypeCiTest -> ViewEvent.ViewEventSessionType.CI_TEST
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.ViewEventSessionType.USER
 }
 
-internal inline fun viewEventSourceToCommonEnum(enumValue: DDRUMViewEventSource):
+internal fun viewEventSourceToCommonEnum(enumValue: DDRUMViewEventSource):
     ViewEvent.ViewEventSource? = when(enumValue) {
   DDRUMViewEventSourceAndroid -> ViewEvent.ViewEventSource.ANDROID
   DDRUMViewEventSourceIos -> ViewEvent.ViewEventSource.IOS
@@ -172,12 +172,11 @@ internal inline fun viewEventSourceToCommonEnum(enumValue: DDRUMViewEventSource)
   DDRUMViewEventSourceUnity -> ViewEvent.ViewEventSource.UNITY
   DDRUMViewEventSourceKotlinMultiplatform -> ViewEvent.ViewEventSource.KOTLIN_MULTIPLATFORM
   DDRUMViewEventSourceNone -> null
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.ViewEventSource.IOS
 }
 
 @Suppress("CAST_NEVER_SUCCEEDS")
-internal inline fun DDRUMViewEventView.toCommonModel(): ViewEvent.ViewEventView =
-    ViewEvent.ViewEventView(
+internal fun DDRUMViewEventView.toCommonModel(): ViewEvent.ViewEventView = ViewEvent.ViewEventView(
   id = id(),
   referrer = referrer(),
   url = url(),
@@ -224,7 +223,7 @@ internal inline fun DDRUMViewEventView.toCommonModel(): ViewEvent.ViewEventView 
   jsRefreshRate = jsRefreshRate()?.toCommonModel(),
 )
 
-internal inline fun viewEventViewLoadingTypeToCommonEnum(enumValue: DDRUMViewEventViewLoadingType):
+internal fun viewEventViewLoadingTypeToCommonEnum(enumValue: DDRUMViewEventViewLoadingType):
     ViewEvent.LoadingType? = when(enumValue) {
   DDRUMViewEventViewLoadingTypeInitialLoad -> ViewEvent.LoadingType.INITIAL_LOAD
   DDRUMViewEventViewLoadingTypeRouteChange -> ViewEvent.LoadingType.ROUTE_CHANGE
@@ -237,49 +236,47 @@ internal inline fun viewEventViewLoadingTypeToCommonEnum(enumValue: DDRUMViewEve
   DDRUMViewEventViewLoadingTypeViewControllerRedisplay ->
       ViewEvent.LoadingType.VIEW_CONTROLLER_REDISPLAY
   DDRUMViewEventViewLoadingTypeNone -> null
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.LoadingType.VIEW_CONTROLLER_DISPLAY
 }
 
-internal inline fun DDRUMViewEventViewAction.toCommonModel(): ViewEvent.Action = ViewEvent.Action(
+internal fun DDRUMViewEventViewAction.toCommonModel(): ViewEvent.Action = ViewEvent.Action(
   count = count().longValue,
 )
 
-internal inline fun DDRUMViewEventViewError.toCommonModel(): ViewEvent.Error = ViewEvent.Error(
+internal fun DDRUMViewEventViewError.toCommonModel(): ViewEvent.Error = ViewEvent.Error(
   count = count().longValue,
 )
 
-internal inline fun DDRUMViewEventViewCrash.toCommonModel(): ViewEvent.Crash = ViewEvent.Crash(
+internal fun DDRUMViewEventViewCrash.toCommonModel(): ViewEvent.Crash = ViewEvent.Crash(
   count = count().longValue,
 )
 
-internal inline fun DDRUMViewEventViewLongTask.toCommonModel(): ViewEvent.LongTask =
-    ViewEvent.LongTask(
+internal fun DDRUMViewEventViewLongTask.toCommonModel(): ViewEvent.LongTask = ViewEvent.LongTask(
   count = count().longValue,
 )
 
-internal inline fun DDRUMViewEventViewFrozenFrame.toCommonModel(): ViewEvent.FrozenFrame =
+internal fun DDRUMViewEventViewFrozenFrame.toCommonModel(): ViewEvent.FrozenFrame =
     ViewEvent.FrozenFrame(
   count = count().longValue,
 )
 
-internal inline fun DDRUMViewEventViewResource.toCommonModel(): ViewEvent.Resource =
-    ViewEvent.Resource(
+internal fun DDRUMViewEventViewResource.toCommonModel(): ViewEvent.Resource = ViewEvent.Resource(
   count = count().longValue,
 )
 
-internal inline fun DDRUMViewEventViewFrustration.toCommonModel(): ViewEvent.Frustration =
+internal fun DDRUMViewEventViewFrustration.toCommonModel(): ViewEvent.Frustration =
     ViewEvent.Frustration(
   count = count().longValue,
 )
 
-internal inline fun DDRUMViewEventViewInForegroundPeriods.toCommonModel():
-    ViewEvent.InForegroundPeriod = ViewEvent.InForegroundPeriod(
+internal fun DDRUMViewEventViewInForegroundPeriods.toCommonModel(): ViewEvent.InForegroundPeriod =
+    ViewEvent.InForegroundPeriod(
   start = start().longValue,
   duration = duration().longValue,
 )
 
 @Suppress("CAST_NEVER_SUCCEEDS")
-internal inline fun DDRUMViewEventViewFlutterBuildTime.toCommonModel(): ViewEvent.FlutterBuildTime =
+internal fun DDRUMViewEventViewFlutterBuildTime.toCommonModel(): ViewEvent.FlutterBuildTime =
     ViewEvent.FlutterBuildTime(
   min = min() as Number,
   max = max() as Number,
@@ -288,16 +285,7 @@ internal inline fun DDRUMViewEventViewFlutterBuildTime.toCommonModel(): ViewEven
 )
 
 @Suppress("CAST_NEVER_SUCCEEDS")
-internal inline fun DDRUMViewEventViewFlutterRasterTime.toCommonModel(): ViewEvent.FlutterBuildTime
-    = ViewEvent.FlutterBuildTime(
-  min = min() as Number,
-  max = max() as Number,
-  average = average() as Number,
-  metricMax = metricMax() as? Number,
-)
-
-@Suppress("CAST_NEVER_SUCCEEDS")
-internal inline fun DDRUMViewEventViewJsRefreshRate.toCommonModel(): ViewEvent.FlutterBuildTime =
+internal fun DDRUMViewEventViewFlutterRasterTime.toCommonModel(): ViewEvent.FlutterBuildTime =
     ViewEvent.FlutterBuildTime(
   min = min() as Number,
   max = max() as Number,
@@ -305,30 +293,39 @@ internal inline fun DDRUMViewEventViewJsRefreshRate.toCommonModel(): ViewEvent.F
   metricMax = metricMax() as? Number,
 )
 
-internal inline fun DDRUMViewEventRUMUser.toCommonModel(): ViewEvent.Usr = ViewEvent.Usr(
+@Suppress("CAST_NEVER_SUCCEEDS")
+internal fun DDRUMViewEventViewJsRefreshRate.toCommonModel(): ViewEvent.FlutterBuildTime =
+    ViewEvent.FlutterBuildTime(
+  min = min() as Number,
+  max = max() as Number,
+  average = average() as Number,
+  metricMax = metricMax() as? Number,
+)
+
+internal fun DDRUMViewEventRUMUser.toCommonModel(): ViewEvent.Usr = ViewEvent.Usr(
   id = id(),
   name = name(),
   email = email(),
   additionalProperties = usrInfo().mapKeys { it.key as String }
 )
 
-internal inline fun DDRUMViewEventRUMConnectivity.toCommonModel(): ViewEvent.Connectivity =
+internal fun DDRUMViewEventRUMConnectivity.toCommonModel(): ViewEvent.Connectivity =
     ViewEvent.Connectivity(
   status = viewEventRUMConnectivityStatusToCommonEnum(status()),
   effectiveType = viewEventRUMConnectivityEffectiveTypeToCommonEnum(effectiveType()),
   cellular = cellular()?.toCommonModel(),
 )
 
-internal inline
+internal
     fun viewEventRUMConnectivityStatusToCommonEnum(enumValue: DDRUMViewEventRUMConnectivityStatus):
     ViewEvent.Status = when(enumValue) {
   DDRUMViewEventRUMConnectivityStatusConnected -> ViewEvent.Status.CONNECTED
   DDRUMViewEventRUMConnectivityStatusNotConnected -> ViewEvent.Status.NOT_CONNECTED
   DDRUMViewEventRUMConnectivityStatusMaybe -> ViewEvent.Status.MAYBE
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.Status.CONNECTED
 }
 
-internal inline
+internal
     fun viewEventRUMConnectivityEffectiveTypeToCommonEnum(enumValue: DDRUMViewEventRUMConnectivityEffectiveType):
     ViewEvent.EffectiveType? = when(enumValue) {
   DDRUMViewEventRUMConnectivityEffectiveTypeSlow2g -> ViewEvent.EffectiveType.SLOW_2G
@@ -336,55 +333,53 @@ internal inline
   DDRUMViewEventRUMConnectivityEffectiveTypeEffectiveType3g -> ViewEvent.EffectiveType.`3G`
   DDRUMViewEventRUMConnectivityEffectiveTypeEffectiveType4g -> ViewEvent.EffectiveType.`4G`
   DDRUMViewEventRUMConnectivityEffectiveTypeNone -> null
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.EffectiveType.`4G`
 }
 
-internal inline fun DDRUMViewEventRUMConnectivityCellular.toCommonModel(): ViewEvent.Cellular =
+internal fun DDRUMViewEventRUMConnectivityCellular.toCommonModel(): ViewEvent.Cellular =
     ViewEvent.Cellular(
   technology = technology(),
   carrierName = carrierName(),
 )
 
-internal inline fun DDRUMViewEventDisplay.toCommonModel(): ViewEvent.Display = ViewEvent.Display(
+internal fun DDRUMViewEventDisplay.toCommonModel(): ViewEvent.Display = ViewEvent.Display(
   viewport = viewport()?.toCommonModel(),
   scroll = scroll()?.toCommonModel(),
 )
 
 @Suppress("CAST_NEVER_SUCCEEDS")
-internal inline fun DDRUMViewEventDisplayViewport.toCommonModel(): ViewEvent.Viewport =
-    ViewEvent.Viewport(
+internal fun DDRUMViewEventDisplayViewport.toCommonModel(): ViewEvent.Viewport = ViewEvent.Viewport(
   width = width() as Number,
   height = height() as Number,
 )
 
 @Suppress("CAST_NEVER_SUCCEEDS")
-internal inline fun DDRUMViewEventDisplayScroll.toCommonModel(): ViewEvent.Scroll =
-    ViewEvent.Scroll(
+internal fun DDRUMViewEventDisplayScroll.toCommonModel(): ViewEvent.Scroll = ViewEvent.Scroll(
   maxDepth = maxDepth() as Number,
   maxDepthScrollTop = maxDepthScrollTop() as Number,
   maxScrollHeight = maxScrollHeight() as Number,
   maxScrollHeightTime = maxScrollHeightTime() as Number,
 )
 
-internal inline fun DDRUMViewEventRUMSyntheticsTest.toCommonModel(): ViewEvent.Synthetics =
+internal fun DDRUMViewEventRUMSyntheticsTest.toCommonModel(): ViewEvent.Synthetics =
     ViewEvent.Synthetics(
   testId = testId(),
   resultId = resultId(),
   injected = injected()?.boolValue,
 )
 
-internal inline fun DDRUMViewEventRUMCITest.toCommonModel(): ViewEvent.CiTest = ViewEvent.CiTest(
+internal fun DDRUMViewEventRUMCITest.toCommonModel(): ViewEvent.CiTest = ViewEvent.CiTest(
   testExecutionId = testExecutionId(),
 )
 
-internal inline fun DDRUMViewEventRUMOperatingSystem.toCommonModel(): ViewEvent.Os = ViewEvent.Os(
+internal fun DDRUMViewEventRUMOperatingSystem.toCommonModel(): ViewEvent.Os = ViewEvent.Os(
   name = name(),
   version = version(),
   build = build(),
   versionMajor = versionMajor(),
 )
 
-internal inline fun DDRUMViewEventRUMDevice.toCommonModel(): ViewEvent.Device = ViewEvent.Device(
+internal fun DDRUMViewEventRUMDevice.toCommonModel(): ViewEvent.Device = ViewEvent.Device(
   type = viewEventRUMDeviceRUMDeviceTypeToCommonEnum(type()),
   name = name(),
   model = model(),
@@ -392,7 +387,7 @@ internal inline fun DDRUMViewEventRUMDevice.toCommonModel(): ViewEvent.Device = 
   architecture = architecture(),
 )
 
-internal inline
+internal
     fun viewEventRUMDeviceRUMDeviceTypeToCommonEnum(enumValue: DDRUMViewEventRUMDeviceRUMDeviceType):
     ViewEvent.DeviceType = when(enumValue) {
   DDRUMViewEventRUMDeviceRUMDeviceTypeMobile -> ViewEvent.DeviceType.MOBILE
@@ -402,10 +397,10 @@ internal inline
   DDRUMViewEventRUMDeviceRUMDeviceTypeGamingConsole -> ViewEvent.DeviceType.GAMING_CONSOLE
   DDRUMViewEventRUMDeviceRUMDeviceTypeBot -> ViewEvent.DeviceType.BOT
   DDRUMViewEventRUMDeviceRUMDeviceTypeOther -> ViewEvent.DeviceType.OTHER
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.DeviceType.OTHER
 }
 
-internal inline fun DDRUMViewEventDD.toCommonModel(): ViewEvent.Dd = ViewEvent.Dd(
+internal fun DDRUMViewEventDD.toCommonModel(): ViewEvent.Dd = ViewEvent.Dd(
   session = session()?.toCommonModel(),
   configuration = configuration()?.toCommonModel(),
   browserSdkVersion = browserSdkVersion(),
@@ -414,21 +409,20 @@ internal inline fun DDRUMViewEventDD.toCommonModel(): ViewEvent.Dd = ViewEvent.D
   replayStats = replayStats()?.toCommonModel(),
 )
 
-internal inline fun DDRUMViewEventDDSession.toCommonModel(): ViewEvent.DdSession =
-    ViewEvent.DdSession(
+internal fun DDRUMViewEventDDSession.toCommonModel(): ViewEvent.DdSession = ViewEvent.DdSession(
   plan = viewEventDDSessionPlanToCommonEnum(plan()),
   sessionPrecondition = viewEventDDSessionRUMSessionPreconditionToCommonEnum(sessionPrecondition()),
 )
 
-internal inline fun viewEventDDSessionPlanToCommonEnum(enumValue: DDRUMViewEventDDSessionPlan):
+internal fun viewEventDDSessionPlanToCommonEnum(enumValue: DDRUMViewEventDDSessionPlan):
     ViewEvent.Plan? = when(enumValue) {
   DDRUMViewEventDDSessionPlanPlan1 -> ViewEvent.Plan.PLAN_1
   DDRUMViewEventDDSessionPlanPlan2 -> ViewEvent.Plan.PLAN_2
   DDRUMViewEventDDSessionPlanNone -> null
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.Plan.PLAN_1
 }
 
-internal inline
+internal
     fun viewEventDDSessionRUMSessionPreconditionToCommonEnum(enumValue: DDRUMViewEventDDSessionRUMSessionPrecondition):
     ViewEvent.SessionPrecondition? = when(enumValue) {
   DDRUMViewEventDDSessionRUMSessionPreconditionUserAppLaunch ->
@@ -445,58 +439,55 @@ internal inline
   DDRUMViewEventDDSessionRUMSessionPreconditionExplicitStop ->
       ViewEvent.SessionPrecondition.EXPLICIT_STOP
   DDRUMViewEventDDSessionRUMSessionPreconditionNone -> null
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.SessionPrecondition.USER_APP_LAUNCH
 }
 
 @Suppress("CAST_NEVER_SUCCEEDS")
-internal inline fun DDRUMViewEventDDConfiguration.toCommonModel(): ViewEvent.Configuration =
+internal fun DDRUMViewEventDDConfiguration.toCommonModel(): ViewEvent.Configuration =
     ViewEvent.Configuration(
   sessionSampleRate = sessionSampleRate() as Number,
   sessionReplaySampleRate = sessionReplaySampleRate() as? Number,
   startSessionReplayRecordingManually = startSessionReplayRecordingManually()?.boolValue,
 )
 
-internal inline fun DDRUMViewEventDDPageStates.toCommonModel(): ViewEvent.PageState =
-    ViewEvent.PageState(
+internal fun DDRUMViewEventDDPageStates.toCommonModel(): ViewEvent.PageState = ViewEvent.PageState(
   state = viewEventDDPageStatesStateToCommonEnum(state()),
   start = start().longValue,
 )
 
-internal inline
-    fun viewEventDDPageStatesStateToCommonEnum(enumValue: DDRUMViewEventDDPageStatesState):
+internal fun viewEventDDPageStatesStateToCommonEnum(enumValue: DDRUMViewEventDDPageStatesState):
     ViewEvent.State = when(enumValue) {
   DDRUMViewEventDDPageStatesStateActive -> ViewEvent.State.ACTIVE
   DDRUMViewEventDDPageStatesStatePassive -> ViewEvent.State.PASSIVE
   DDRUMViewEventDDPageStatesStateHidden -> ViewEvent.State.HIDDEN
   DDRUMViewEventDDPageStatesStateFrozen -> ViewEvent.State.FROZEN
   DDRUMViewEventDDPageStatesStateTerminated -> ViewEvent.State.TERMINATED
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.State.ACTIVE
 }
 
-internal inline fun DDRUMViewEventDDReplayStats.toCommonModel(): ViewEvent.ReplayStats =
+internal fun DDRUMViewEventDDReplayStats.toCommonModel(): ViewEvent.ReplayStats =
     ViewEvent.ReplayStats(
   recordsCount = recordsCount()?.longValue,
   segmentsCount = segmentsCount()?.longValue,
   segmentsTotalRawSize = segmentsTotalRawSize()?.longValue,
 )
 
-internal inline fun DDRUMViewEventRUMEventAttributes.toCommonModel(): ViewEvent.Context =
+internal fun DDRUMViewEventRUMEventAttributes.toCommonModel(): ViewEvent.Context =
     ViewEvent.Context(
   additionalProperties = contextInfo().mapKeys { it.key as String }
 )
 
-internal inline fun DDRUMViewEventContainer.toCommonModel(): ViewEvent.Container =
-    ViewEvent.Container(
+internal fun DDRUMViewEventContainer.toCommonModel(): ViewEvent.Container = ViewEvent.Container(
   view = view().toCommonModel(),
   source = viewEventContainerSourceToCommonEnum(source()),
 )
 
-internal inline fun DDRUMViewEventContainerView.toCommonModel(): ViewEvent.ContainerView =
+internal fun DDRUMViewEventContainerView.toCommonModel(): ViewEvent.ContainerView =
     ViewEvent.ContainerView(
   id = id(),
 )
 
-internal inline fun viewEventContainerSourceToCommonEnum(enumValue: DDRUMViewEventContainerSource):
+internal fun viewEventContainerSourceToCommonEnum(enumValue: DDRUMViewEventContainerSource):
     ViewEvent.ViewEventSource = when(enumValue) {
   DDRUMViewEventContainerSourceAndroid -> ViewEvent.ViewEventSource.ANDROID
   DDRUMViewEventContainerSourceIos -> ViewEvent.ViewEventSource.IOS
@@ -506,24 +497,22 @@ internal inline fun viewEventContainerSourceToCommonEnum(enumValue: DDRUMViewEve
   DDRUMViewEventContainerSourceRoku -> ViewEvent.ViewEventSource.ROKU
   DDRUMViewEventContainerSourceUnity -> ViewEvent.ViewEventSource.UNITY
   DDRUMViewEventContainerSourceKotlinMultiplatform -> ViewEvent.ViewEventSource.KOTLIN_MULTIPLATFORM
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.ViewEventSource.IOS
 }
 
-internal inline fun DDRUMViewEventFeatureFlags.toCommonModel(): ViewEvent.Context =
-    ViewEvent.Context(
+internal fun DDRUMViewEventFeatureFlags.toCommonModel(): ViewEvent.Context = ViewEvent.Context(
   additionalProperties = featureFlagsInfo().mapKeys { it.key as String }
 )
 
-internal inline fun DDRUMViewEventPrivacy.toCommonModel(): ViewEvent.Privacy = ViewEvent.Privacy(
+internal fun DDRUMViewEventPrivacy.toCommonModel(): ViewEvent.Privacy = ViewEvent.Privacy(
   replayLevel = viewEventPrivacyReplayLevelToCommonEnum(replayLevel()),
 )
 
-internal inline
-    fun viewEventPrivacyReplayLevelToCommonEnum(enumValue: DDRUMViewEventPrivacyReplayLevel):
+internal fun viewEventPrivacyReplayLevelToCommonEnum(enumValue: DDRUMViewEventPrivacyReplayLevel):
     ViewEvent.ReplayLevel = when(enumValue) {
   DDRUMViewEventPrivacyReplayLevelAllow -> ViewEvent.ReplayLevel.ALLOW
   DDRUMViewEventPrivacyReplayLevelMask -> ViewEvent.ReplayLevel.MASK
   DDRUMViewEventPrivacyReplayLevelMaskUserInput -> ViewEvent.ReplayLevel.MASK_USER_INPUT
-  else -> throw IllegalArgumentException("Unknown value $enumValue")
+  else -> ViewEvent.ReplayLevel.MASK_USER_INPUT
 }
 


### PR DESCRIPTION
### What does this PR do?

Even though mapping functions code generation covers all the enum values available, it covers it for the given native SDK version.

It can be the case that KMP SDK is used with a newer version of the native SDK than it was compiled for. In this case we may have enum values coming from the native models not known to the KMP SDK and get an exception in this case.

To avoid that we will use fallback values for enums: it is better to have slightly different value than crash/skip mapping. All the properties having enum values type are immutable, so the fallback value won't be written back to the native model anyway.

Also this PR removes `inline` modifier from iOS-generated methods, because it is pretty much useless there: it won't be any performance gain and there is no dex count limit like on Android.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

