### PR TITLE
Stop generating podspec for public modules

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -47,13 +47,9 @@ val generateLibConfigTask = tasks.register("generateLibConfig", Sync::class) {
 kotlin {
 
     cocoapods {
-        // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
-        // so what is below for podspec description is just a fake thing to make tooling happy
-        version = ProjectConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
-        name = "DatadogKMPCore"
-        summary = "Official Datadog KMP SDK for iOS."
+        noPodspec()
 
         framework {
             baseName = "DatadogKMPCore"

--- a/features/logs/build.gradle.kts
+++ b/features/logs/build.gradle.kts
@@ -4,7 +4,6 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.build.ProjectConfig
 import com.datadog.build.plugin.jsonschema.SchemaLocation
 import dev.mokkery.MockMode
 
@@ -27,13 +26,9 @@ plugins {
 kotlin {
 
     cocoapods {
-        // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
-        // so what is below for podspec description is just a fake thing to make tooling happy
-        version = ProjectConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
-        name = "DatadogKMPLogs"
-        summary = "Official Datadog KMP Logs SDK for iOS."
+        noPodspec()
 
         framework {
             baseName = "DatadogKMPLogs"

--- a/features/rum/build.gradle.kts
+++ b/features/rum/build.gradle.kts
@@ -4,7 +4,6 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.build.ProjectConfig
 import com.datadog.build.plugin.jsonschema.SchemaLocation
 import dev.mokkery.MockMode
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
@@ -28,13 +27,9 @@ plugins {
 kotlin {
 
     cocoapods {
-        // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
-        // so what is below for podspec description is just a fake thing to make tooling happy
-        version = ProjectConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
-        name = "DatadogKMPRUM"
-        summary = "Official Datadog KMP RUM SDK for iOS."
+        noPodspec()
 
         framework {
             baseName = "DatadogKMPRUM"

--- a/features/webview/build.gradle.kts
+++ b/features/webview/build.gradle.kts
@@ -4,7 +4,6 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.build.ProjectConfig
 import dev.mokkery.MockMode
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.konan.target.Family
@@ -27,13 +26,9 @@ plugins {
 kotlin {
 
     cocoapods {
-        // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
-        // so what is below for podspec description is just a fake thing to make tooling happy
-        version = ProjectConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
-        name = "DatadogKMPWebView"
-        summary = "Official Datadog KMP WebView tracking SDK for iOS."
+        noPodspec()
 
         framework {
             baseName = "DatadogKMPWebView"

--- a/integrations/ktor/build.gradle.kts
+++ b/integrations/ktor/build.gradle.kts
@@ -4,7 +4,6 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.build.ProjectConfig
 import dev.mokkery.MockMode
 
 plugins {
@@ -25,13 +24,9 @@ plugins {
 kotlin {
 
     cocoapods {
-        // cannot use noPodSpec, because of https://youtrack.jetbrains.com/issue/KT-63331
-        // so what is below for podspec description is just a fake thing to make tooling happy
-        version = ProjectConfig.VERSION.name
         // need to build with XCode 15
         ios.deploymentTarget = "12.0"
-        name = "DatadogKMPKtor"
-        summary = "Official Datadog SDK Ktor integration for iOS."
+        noPodspec()
 
         framework {
             baseName = "DatadogKMPKtor"


### PR DESCRIPTION
### What does this PR do?

`podspec` is not needed, because these modules are not consumed by the iOS app directly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

