### PR TITLE
Remove Github -> Gitlab git URL overwrite for macOS runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,9 @@ ios-unit-test:
   tags: [ "macos:sonoma" ]
   image: $CI_IMAGE_DOCKER
   timeout: 1h
+  # Remove URL re-write, otherwise dd-sdk-ios is attempted to be cloned from Gitlab instead of Github as requested
+  before_script:
+    - git config --global --list | grep --line-buffered -oe "url.https://gitlab-ci-token:.*@gitlab.ddbuild.io/DataDog/" | xargs -I {} git config --global --remove {}
   script:
     # TODO RUM-4602 Datadog Java Agent fails to start (macOS problem? arm64 problem?)
     - pod repo update
@@ -146,6 +149,9 @@ sample-app-build-ios:
   timeout: 1h
   variables:
     BUILD_DESTINATION: "platform=iOS Simulator,name=iPhone 15 Pro Max,OS=17.4"
+  # Remove URL re-write, otherwise dd-sdk-ios is attempted to be cloned from Gitlab instead of Github as requested
+  before_script:
+    - git config --global --list | grep --line-buffered -oe "url.https://gitlab-ci-token:.*@gitlab.ddbuild.io/DataDog/" | xargs -I {} git config --global --remove {}
   script:
     - pod repo update
     # temporary workaround for RUM-4282


### PR DESCRIPTION
### What does this PR do?

This PR removes Github -> Gitlab git URL overwrite for macOS runner. If not removed, `dd-sdk-ios` is attempted to be cloned from Gitlab instead of Github as requested, leading to the permission error.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

