### PR TITLE
Lift CrashReporter linker workaround to the convention plugin

### DIFF
--- a/features/logs/build.gradle.kts
+++ b/features/logs/build.gradle.kts
@@ -6,7 +6,6 @@
 
 import com.datadog.build.plugin.jsonschema.SchemaLocation
 import dev.mokkery.MockMode
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -62,28 +61,6 @@ kotlin {
             implementation(libs.kotlin.test)
             implementation(projects.tools.unit)
         }
-    }
-
-    targets.withType<KotlinNativeTargetWithSimulatorTests> {
-        compilations
-            .getByName("test")
-            .compileTaskProvider {
-                compilerOptions {
-                    freeCompilerArgs.addAll(
-                        listOf(
-                            "-linker-options",
-                            // TODO RUM-6046 Name of CrashReporter framework is not passed, so have
-                            //  to pass it explicitly, otherwise konanc invocation with linking (ld) fails
-                            //  to locate framework for PLCrashReporter pod. Kotlin Compiler bug?
-                            "-framework CrashReporter " +
-                                // TODO RUM-6047 Kotlin Compiler cannot locate these during the linking
-                                //  done via pods integration
-                                "-U __swift_FORCE_LOAD_\$_swiftCompatibility56 " +
-                                "-U __swift_FORCE_LOAD_\$_swiftCompatibilityConcurrency"
-                        )
-                    )
-                }
-            }
     }
 }
 

--- a/features/rum/build.gradle.kts
+++ b/features/rum/build.gradle.kts
@@ -6,7 +6,6 @@
 
 import com.datadog.build.plugin.jsonschema.SchemaLocation
 import dev.mokkery.MockMode
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -75,28 +74,6 @@ kotlin {
         // 1.8 everything is in the main stdlib.
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk7")
         exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
-    }
-
-    targets.withType<KotlinNativeTargetWithSimulatorTests> {
-        compilations
-            .getByName("test")
-            .compileTaskProvider {
-                compilerOptions {
-                    freeCompilerArgs.addAll(
-                        listOf(
-                            "-linker-options",
-                            // TODO RUM-6046 Name of CrashReporter framework is not passed, so have
-                            //  to pass it explicitly, otherwise konanc invocation with linking (ld) fails
-                            //  to locate framework for PLCrashReporter pod. Kotlin Compiler bug?
-                            "-framework CrashReporter " +
-                                // TODO RUM-6047 Kotlin Compiler cannot locate these during the linking
-                                //  done via pods integration
-                                "-U __swift_FORCE_LOAD_\$_swiftCompatibility56 " +
-                                "-U __swift_FORCE_LOAD_\$_swiftCompatibilityConcurrency"
-                        )
-                    )
-                }
-            }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR just moves some repeated build configuration logic to the convention plugin.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

