### PR TITLE
Rename master to main branch in CodeQL config

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "**" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master", "develop", "release/**", "feature/**" ]
+    branches: [ "main", "develop", "release/**", "feature/**" ]
 
 jobs:
   analyze:


### PR DESCRIPTION
### What does this PR do?

CodeQL config was copied from https://github.com/DataDog/dd-sdk-android where `master` exists, but it is called `main` in this repo.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

