### PR TITLE
RUM-5233: Report response size in Ktor instrumentation

### DIFF
--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
@@ -21,6 +21,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
 import io.ktor.http.HttpMethod
+import io.ktor.http.contentLength
 import io.ktor.util.AttributeKey
 
 internal class DatadogKtorPlugin(
@@ -70,7 +71,7 @@ internal class DatadogKtorPlugin(
             rumMonitor.stopResource(
                 key = requestId,
                 statusCode = response.status.value,
-                size = null, // TODO RUM-5233 report request size
+                size = response.contentLength(), // TODO RUM-6382 Report content size if header is missing
                 kind = RumResourceKind.NATIVE,
                 attributes = emptyMap()
             )


### PR DESCRIPTION
### What does this PR do?

This PR brings the ability to report response size in Ktor instrumentation by reading `Content-Size` header.

However, it may be missing for the chunked response or for the streams (in that case we cannot report response size anyway), or engines like OkHttp may drop it compression-like `Content-Encoding` is applied.

In Android SDK in that case we try to read response body manually, but it seems it is somewhat complicated / dangerous to do with Ktor, because:

* Generally speaking `HttpResponse.body` doesn’t allow being read twice (see [doc](https://api.ktor.io/older/2.3.12/ktor-client/ktor-client-core/io.ktor.client.call/body.html)), meaning that if we read it in our instrumentation, client will later get an exception trying to read it as well.

* This exception is not thrown if read is done from the `HttpCall` obtained from `HttpResponse.call.save()` ([doc](https://api.ktor.io/older/2.3.12/ktor-client/ktor-client-core/io.ktor.client.call/save.html)), because `SavedHttpCall` allows multiple reads of the body, but we cannot propagate this call to the client and doc also says that `save()` will close the origin.

* There is `HttpResponse.content: ByteReadChannel`, but it is marked as `InternalApi` and doesn’t exist anymore in Ktor 3, meaning there will be a crash if we try to access this property in a runtime using Ktor 3 (in Ktor 3 this property got renamed to `rawContent`). Also I’m not sure if client can still read the body after we read the content channel.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

