### PR TITLE
Don't use `kotlinx.datetime` on Android

### DIFF
--- a/integrations/ktor/android-transitiveDependencies
+++ b/integrations/ktor/android-transitiveDependencies
@@ -14,9 +14,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22                  :  969 b
 org.jetbrains.kotlin:kotlin-stdlib:2.0.20                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1         : 1512 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.1             :  953 b 
-org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.0                :  648 Kb
 org.jetbrains:annotations:23.0.0                                :   28 Kb
 org.slf4j:slf4j-api:1.7.36                                      :   40 Kb
 
-Total transitive dependencies size                              :    6 Mb
+Total transitive dependencies size                              :    5 Mb
 

--- a/integrations/ktor/build.gradle.kts
+++ b/integrations/ktor/build.gradle.kts
@@ -50,10 +50,12 @@ kotlin {
             api(projects.features.rum)
             implementation(libs.ktor.client.core)
             implementation(libs.uuid)
-            implementation(libs.kotlinx.datetime)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+        }
+        iosMain.dependencies {
+            implementation(libs.kotlinx.datetime)
         }
     }
 }

--- a/integrations/ktor/src/androidMain/kotlin/com/datadog/kmp/ktor/RandomExt.android.kt
+++ b/integrations/ktor/src/androidMain/kotlin/com/datadog/kmp/ktor/RandomExt.android.kt
@@ -6,9 +6,4 @@
 
 package com.datadog.kmp.ktor
 
-import kotlin.random.Random
-
-// TODO RUM-6453 Documentation says that it is not thread-safe for JVM target, we need to handle this
-internal val RNG = Random(seed())
-
-internal expect fun seed(): Long
+internal actual fun seed(): Long = System.nanoTime()

--- a/integrations/ktor/src/androidMain/kotlin/com/datadog/kmp/ktor/internal/trace/DefaultTraceIdGenerator.kt
+++ b/integrations/ktor/src/androidMain/kotlin/com/datadog/kmp/ktor/internal/trace/DefaultTraceIdGenerator.kt
@@ -4,11 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.kmp.ktor
+package com.datadog.kmp.ktor.internal.trace
 
-import kotlin.random.Random
+import java.util.concurrent.TimeUnit
 
-// TODO RUM-6453 Documentation says that it is not thread-safe for JVM target, we need to handle this
-internal val RNG = Random(seed())
-
-internal expect fun seed(): Long
+internal actual fun epochSeconds(): Long = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/trace/DefaultTraceIdGenerator.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/trace/DefaultTraceIdGenerator.kt
@@ -7,7 +7,6 @@
 package com.datadog.kmp.ktor.internal.trace
 
 import com.datadog.kmp.ktor.RNG
-import kotlinx.datetime.Clock
 
 internal class DefaultTraceIdGenerator : TraceIdGenerator {
 
@@ -16,7 +15,7 @@ internal class DefaultTraceIdGenerator : TraceIdGenerator {
         var idLo: ULong
         do {
             // 32-bit unix seconds + 32 bits of zero in decimal
-            idHi = (Clock.System.now().epochSeconds shl CLOCK_SHIFT).toULong()
+            idHi = (epochSeconds() shl CLOCK_SHIFT).toULong()
             idLo = RNG.nextLong(1, Long.MAX_VALUE).toULong()
         } while (idHi == INVALID_ID && idLo == INVALID_ID)
         return TraceId(idHi, idLo)
@@ -28,3 +27,5 @@ internal class DefaultTraceIdGenerator : TraceIdGenerator {
         private const val CLOCK_SHIFT = 32
     }
 }
+
+internal expect fun epochSeconds(): Long

--- a/integrations/ktor/src/iosMain/kotlin/com/datadog/kmp/ktor/RandomExt.ios.kt
+++ b/integrations/ktor/src/iosMain/kotlin/com/datadog/kmp/ktor/RandomExt.ios.kt
@@ -6,9 +6,6 @@
 
 package com.datadog.kmp.ktor
 
-import kotlin.random.Random
+import kotlinx.datetime.Clock
 
-// TODO RUM-6453 Documentation says that it is not thread-safe for JVM target, we need to handle this
-internal val RNG = Random(seed())
-
-internal expect fun seed(): Long
+internal actual fun seed(): Long = Clock.System.now().nanosecondsOfSecond.toLong()

--- a/integrations/ktor/src/iosMain/kotlin/com/datadog/kmp/ktor/internal/trace/DefaultTraceIdGenerator.kt
+++ b/integrations/ktor/src/iosMain/kotlin/com/datadog/kmp/ktor/internal/trace/DefaultTraceIdGenerator.kt
@@ -4,11 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.kmp.ktor
+package com.datadog.kmp.ktor.internal.trace
 
-import kotlin.random.Random
+import kotlinx.datetime.Clock
 
-// TODO RUM-6453 Documentation says that it is not thread-safe for JVM target, we need to handle this
-internal val RNG = Random(seed())
-
-internal expect fun seed(): Long
+internal actual fun epochSeconds(): Long = Clock.System.now().epochSeconds


### PR DESCRIPTION
### What does this PR do?

`kotlinx.datetime` is using `java.time` package APIs on Android ([doc](https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#using-in-your-projects)), which is available only since API 26, making application crash if it is running on the lower APIs.

This PR removes its usage in case of Android (and continue to use it in case of iOS).

On Android we will use `System.nanoTime` for now for the random seed.

Fixes #96.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

