### PR TITLE
Migrate Slack notifier to k8s runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,9 @@
-include:
-  - 'https://gitlab-templates.ddbuild.io/slack-notifier/v1/template.yml'
-
 # SETUP
 
 variables:
   CURRENT_CI_IMAGE: "2"
   CI_IMAGE_DOCKER: registry.ddbuild.io/ci/dd-sdk-kotlin-multiplatform:$CURRENT_CI_IMAGE
+  SLACK_NOTIFIER_IMAGE: registry.ddbuild.io/slack-notifier:latest
   GIT_DEPTH: 6
 
   DD_SERVICE: "dd-sdk-kotlin-multiplatform"
@@ -237,7 +235,8 @@ publish:release-ktor:
 # SLACK NOTIFICATIONS
 
 notify:publish-release-success:
-  extends: .slack-notifier-base
+  image: $SLACK_NOTIFIER_IMAGE
+  tags: [ "arch:amd64" ]
   stage: notify
   when: on_success
   only:
@@ -248,7 +247,8 @@ notify:publish-release-success:
     - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
 
 notify:publish-release-failure:
-  extends: .slack-notifier-base
+  image: $SLACK_NOTIFIER_IMAGE
+  tags: [ "arch:amd64" ]
   stage: notify
   when: on_failure
   only:


### PR DESCRIPTION
### What does this PR do?

Existing Slack notifier is using old Docker runner, which is not allowed in the repo unless legacy role is enabled.

This PR makes use of Slack notifications in k8s runner.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

