### PR TITLE
RUM-7550: Add RUM Resource attributes provider for Ktor instrumentation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,7 @@ val jvmUnitTestReleaseAllTask = tasks.register("jvmUnitTestReleaseAll") {
 }
 
 // will cover Android-specific tests + tests from common source set
-tasks.register("jvmUnitTestAll") {
+val jvmUnitTestAllTask = tasks.register("jvmUnitTestAll") {
     dependsOn(
         jvmUnitTestDebugAllTask,
         jvmUnitTestReleaseAllTask,
@@ -134,8 +134,12 @@ val tvosUnitTestAllTask = tasks.register("tvosUnitTestAll") {
     dependsOn(subProjectsTestTasks)
 }
 
-tasks.register("appleUnitTestAll") {
+val appleUnitTestAllTask = tasks.register("appleUnitTestAll") {
     dependsOn(iosUnitTestAllTask, tvosUnitTestAllTask)
+}
+
+tasks.register("unitTestAll") {
+    dependsOn(jvmUnitTestAllTask, appleUnitTestAllTask)
 }
 
 tasks.register("lintCheckAll") {

--- a/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ViewAttributesProvider.kt
+++ b/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/tracking/ViewAttributesProvider.kt
@@ -10,7 +10,7 @@ import android.view.View
 import com.datadog.android.rum.RumAttributes
 
 /**
- * Provides the extra attributes for the  as Map<String,Any?>.
+ * Provides the extra attributes for the [View] as Map<String,Any?>.
  */
 fun interface ViewAttributesProvider {
 

--- a/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/tracking/DefaultUIKitRUMViewsPredicate.kt
+++ b/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/tracking/DefaultUIKitRUMViewsPredicate.kt
@@ -11,7 +11,7 @@ import platform.UIKit.UIViewController
 
 /**
  * Default implementation of [UIKitRUMViewsPredicate].
- * It names  RUM Views by the names of their [UIViewController] subclasses.
+ * It names RUM Views by the names of their [UIViewController] subclasses.
  */
 class DefaultUIKitRUMViewsPredicate : UIKitRUMViewsPredicate {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }

--- a/integrations/ktor/api/commonMain/apiSurface
+++ b/integrations/ktor/api/commonMain/apiSurface
@@ -1,7 +1,11 @@
-fun datadogKtorPlugin(Map<String, Set<TracingHeaderType>> = emptyMap(), Float = DEFAULT_TRACE_SAMPLE_RATE): io.ktor.client.plugins.api.ClientPlugin<Unit>
+fun datadogKtorPlugin(Map<String, Set<TracingHeaderType>> = emptyMap(), Float = DEFAULT_TRACE_SAMPLE_RATE, RumResourceAttributesProvider = DefaultRumResourceAttributesProvider): io.ktor.client.plugins.api.ClientPlugin<Unit>
 const val RUM_TRACE_ID: String
 const val RUM_SPAN_ID: String
 const val RUM_RULE_PSR: String
+interface com.datadog.kmp.ktor.RumResourceAttributesProvider
+  fun onRequest(io.ktor.client.request.HttpRequestData): Map<String, Any?>
+  fun onResponse(io.ktor.client.statement.HttpResponse): Map<String, Any?>
+  fun onError(io.ktor.client.request.HttpRequestData, Throwable): Map<String, Any?>
 enum com.datadog.kmp.ktor.TracingHeaderType
   - DATADOG
   - B3

--- a/integrations/ktor/build.gradle.kts
+++ b/integrations/ktor/build.gradle.kts
@@ -5,6 +5,8 @@
  */
 
 import dev.mokkery.MockMode
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -54,10 +56,19 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.ktor.client.mock)
+            implementation(projects.tools.unit)
         }
         appleMain.dependencies {
             implementation(libs.kotlinx.datetime)
         }
+    }
+
+    // fix for w: KLIB resolver: The same 'unique_name=org.jetbrains.kotlinx:atomicfu' found in more than one library
+    // see https://youtrack.jetbrains.com/issue/KT-71206, should be fixed in Kotlin 2.1.0
+    targets.withType<KotlinNativeTargetWithSimulatorTests> {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        compilerOptions.allWarningsAsErrors = false
     }
 }
 

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
@@ -10,6 +10,7 @@ import com.datadog.kmp.ktor.internal.plugin.DatadogKtorPlugin
 import com.datadog.kmp.ktor.internal.plugin.buildClientPlugin
 import com.datadog.kmp.ktor.internal.trace.DefaultSpanIdGenerator
 import com.datadog.kmp.ktor.internal.trace.DefaultTraceIdGenerator
+import com.datadog.kmp.ktor.sampling.FixedRateSampler
 import com.datadog.kmp.rum.RumMonitor
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.api.ClientPlugin
@@ -22,16 +23,20 @@ internal const val DEFAULT_TRACE_SAMPLE_RATE: Float = 20f
  * to use to handle distributed traces. For a default setup, we recommend using the DATADOG + TRACECONTEXT header types
  * for the hosts you own.
  * @param traceSamplingRate the sampling rate for the tracing (between 0 and 100)
+ * @param rumResourceAttributesProvider which listens on the intercepted Ktor call chain
+ * and offers the possibility to add custom attributes to the RUM resource events.
  */
 fun datadogKtorPlugin(
     tracedHosts: Map<String, Set<TracingHeaderType>> = emptyMap(),
-    traceSamplingRate: Float = DEFAULT_TRACE_SAMPLE_RATE
+    traceSamplingRate: Float = DEFAULT_TRACE_SAMPLE_RATE,
+    rumResourceAttributesProvider: RumResourceAttributesProvider = DefaultRumResourceAttributesProvider
 ): ClientPlugin<Unit> {
     return DatadogKtorPlugin(
         RumMonitor.get(),
         tracedHosts,
-        traceSamplingRate,
+        FixedRateSampler(traceSamplingRate),
         DefaultTraceIdGenerator(),
-        DefaultSpanIdGenerator()
+        DefaultSpanIdGenerator(),
+        rumResourceAttributesProvider
     ).buildClientPlugin()
 }

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/RumResourceAttributesProvider.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/RumResourceAttributesProvider.kt
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.ktor
+
+import io.ktor.client.request.HttpRequest
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.statement.HttpResponse
+
+/**
+ * Provider which listens for the Ktor [HttpRequestData] -> [HttpResponse] (or [Throwable]) chain and
+ * offers a possibility to add custom attributes to the RUM Resource event.
+ */
+interface RumResourceAttributesProvider {
+
+    /**
+     * Offers a possibility to provide custom attributes at the request creation stage, which later will be attached
+     * the RUM resource event associated with the request.
+     * @param request the intercepted [HttpRequestData]
+     */
+    fun onRequest(request: HttpRequestData): Map<String, Any?>
+
+    /**
+     * Offers a possibility to create custom attributes at the response receive stage, which later will be attached to
+     * the RUM resource event associated with the request.
+     * @param response the [HttpResponse] response
+     */
+    fun onResponse(response: HttpResponse): Map<String, Any?>
+
+    /**
+     * Offers a possibility to create custom attributes at the error receive stage, which later will be attached to
+     * the RUM resource event associated with the request.
+     * @param request the intercepted [HttpRequestData]
+     * @param throwable in case an error occurred during the [HttpRequest]
+     */
+    fun onError(request: HttpRequestData, throwable: Throwable): Map<String, Any?>
+}
+
+internal object DefaultRumResourceAttributesProvider : RumResourceAttributesProvider {
+    override fun onRequest(request: HttpRequestData) = emptyMap<String, Any?>()
+    override fun onResponse(response: HttpResponse) = emptyMap<String, Any?>()
+    override fun onError(request: HttpRequestData, throwable: Throwable) = emptyMap<String, Any?>()
+}

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
@@ -7,16 +7,19 @@
 package com.datadog.kmp.ktor.internal.plugin
 
 import com.benasher44.uuid.uuid4
-import com.datadog.kmp.ktor.RNG
 import com.datadog.kmp.ktor.RUM_RULE_PSR
 import com.datadog.kmp.ktor.RUM_SPAN_ID
 import com.datadog.kmp.ktor.RUM_TRACE_ID
+import com.datadog.kmp.ktor.RumResourceAttributesProvider
 import com.datadog.kmp.ktor.TracingHeaderType
 import com.datadog.kmp.ktor.internal.trace.SpanIdGenerator
 import com.datadog.kmp.ktor.internal.trace.TraceIdGenerator
+import com.datadog.kmp.ktor.sampling.Sampler
 import com.datadog.kmp.rum.RumMonitor
 import com.datadog.kmp.rum.RumResourceKind
 import com.datadog.kmp.rum.RumResourceMethod
+import io.ktor.client.plugins.api.OnRequestContext
+import io.ktor.client.plugins.api.OnResponseContext
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
@@ -28,15 +31,16 @@ import io.ktor.util.AttributeKey
 internal class DatadogKtorPlugin(
     private val rumMonitor: RumMonitor,
     private val tracedHosts: Map<String, Set<TracingHeaderType>>,
-    private val traceSamplingRate: Float,
+    private val traceSampler: Sampler,
     private val traceIdGenerator: TraceIdGenerator,
-    private val spanIdGenerator: SpanIdGenerator
+    private val spanIdGenerator: SpanIdGenerator,
+    private val rumResourceAttributesProvider: RumResourceAttributesProvider
 ) : KtorPlugin {
 
     override val pluginName: String = PLUGIN_NAME
 
-    override fun onRequest(onRequestContext: Any, request: HttpRequestBuilder, content: Any) {
-        val isSampledIn = RNG.nextDouble(MIN_SAMPLE_RATE, MAX_SAMPLE_RATE).toFloat() < traceSamplingRate
+    override fun onRequest(onRequestContext: OnRequestContext, request: HttpRequestBuilder, content: Any) {
+        val isSampledIn = traceSampler.sample()
         val traceHeaderTypes = traceHeaderTypesForHost(request.url.host)
 
         val traceId = traceIdGenerator.generateTraceId()
@@ -48,7 +52,7 @@ internal class DatadogKtorPlugin(
             }
             request.attributes.put(DD_TRACE_ID_ATTR, traceId.toHexString())
             request.attributes.put(DD_SPAN_ID_ATTR, spanId.raw.toString())
-            request.attributes.put(DD_RULE_PSR_ATTR, traceSamplingRate)
+            request.attributes.put(DD_RULE_PSR_ATTR, traceSampler.sampleRate)
         } else {
             TracingHeaderType.entries.forEach { headerType ->
                 headerType.injectHeaders(request, false, traceId, spanId)
@@ -61,28 +65,30 @@ internal class DatadogKtorPlugin(
             key = requestId,
             method = request.method.asRumMethod(),
             url = request.url.buildString(),
-            attributes = emptyMap()
+            attributes = rumResourceAttributesProvider.onRequest(request.build())
         )
     }
-    override fun onResponse(onResponseContext: Any, response: HttpResponse) {
+
+    override fun onResponse(onResponseContext: OnResponseContext, response: HttpResponse) {
         val requestAttributes = response.request.attributes
         val requestId = requestAttributes.getOrNull(DD_REQUEST_ID_ATTR)
         if (requestId != null) {
+            val tracingAttributes = mutableMapOf<String, Any?>().apply {
+                val traceId = requestAttributes.getOrNull(DD_TRACE_ID_ATTR)
+                val spanId = requestAttributes.getOrNull(DD_SPAN_ID_ATTR)
+                val rulePsr = requestAttributes.getOrNull(DD_RULE_PSR_ATTR)
+                if (traceId != null && spanId != null && rulePsr != null) {
+                    put(RUM_TRACE_ID, traceId)
+                    put(RUM_SPAN_ID, spanId)
+                    put(RUM_RULE_PSR, rulePsr)
+                }
+            }
             rumMonitor.stopResource(
                 key = requestId,
                 statusCode = response.status.value,
                 size = response.contentLength(), // TODO RUM-6382 Report content size if header is missing
                 kind = RumResourceKind.NATIVE,
-                attributes = mutableMapOf<String, Any?>().apply {
-                    val traceId = requestAttributes.getOrNull(DD_TRACE_ID_ATTR)
-                    val spanId = requestAttributes.getOrNull(DD_SPAN_ID_ATTR)
-                    val rulePsr = requestAttributes.getOrNull(DD_RULE_PSR_ATTR)
-                    if (traceId != null && spanId != null && rulePsr != null) {
-                        put(RUM_TRACE_ID, traceId)
-                        put(RUM_SPAN_ID, spanId)
-                        put(RUM_RULE_PSR, rulePsr)
-                    }
-                }
+                attributes = rumResourceAttributesProvider.onResponse(response) + tracingAttributes
             )
         } else {
             // TODO RUM-5254 handle missing request id case
@@ -98,14 +104,15 @@ internal class DatadogKtorPlugin(
                 key = requestId,
                 statusCode = null,
                 message = "Ktor request error $method $url",
-                throwable = throwable
+                throwable = throwable,
+                attributes = rumResourceAttributesProvider.onError(request.build(), throwable)
             )
         } else {
             // TODO RUM-5254 handle missing request id case
         }
     }
 
-    private fun traceHeaderTypesForHost(host: String): Set<TracingHeaderType>? {
+    internal fun traceHeaderTypesForHost(host: String): Set<TracingHeaderType>? {
         return tracedHosts.getOrElse(host) {
             tracedHosts.entries.firstOrNull { host.endsWith(".${it.key}") }?.value ?: tracedHosts["*"]
         }
@@ -136,7 +143,5 @@ internal class DatadogKtorPlugin(
         internal val DD_TRACE_ID_ATTR = AttributeKey<String>(RUM_TRACE_ID)
         internal val DD_SPAN_ID_ATTR = AttributeKey<String>(RUM_SPAN_ID)
         internal val DD_RULE_PSR_ATTR = AttributeKey<Float>(RUM_RULE_PSR)
-        internal const val MIN_SAMPLE_RATE: Double = 0.0
-        internal const val MAX_SAMPLE_RATE: Double = 100.0
     }
 }

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/KtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/KtorPlugin.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.kmp.ktor.internal.plugin
 
+import io.ktor.client.plugins.api.OnRequestContext
+import io.ktor.client.plugins.api.OnResponseContext
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
 
@@ -14,13 +16,13 @@ internal interface KtorPlugin {
     val pluginName: String
 
     fun onRequest(
-        onRequestContext: Any,
+        onRequestContext: OnRequestContext,
         request: HttpRequestBuilder,
         content: Any
     )
 
     fun onResponse(
-        onResponseContext: Any,
+        onResponseContext: OnResponseContext,
         response: HttpResponse
     )
 

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/sampling/Sampler.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/sampling/Sampler.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.ktor.sampling
+
+import com.datadog.kmp.ktor.RNG
+
+internal interface Sampler {
+    // strictly speaking if there is some variable sample rate, result of sampleRate call may be different from the
+    // value used for the sample() decision, so not the best API. But since it is internal and we have only single
+    // implementation so far, it is fine.
+    val sampleRate: Float
+    fun sample(): Boolean
+}
+
+internal class FixedRateSampler(override val sampleRate: Float) : Sampler {
+    override fun sample(): Boolean {
+        return RNG.nextDouble(MIN_SAMPLE_RATE, MAX_SAMPLE_RATE).toFloat() < sampleRate
+    }
+
+    companion object {
+        const val MIN_SAMPLE_RATE: Double = 0.0
+        const val MAX_SAMPLE_RATE: Double = 100.0
+    }
+}

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
@@ -1,0 +1,349 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.ktor.internal.plugin
+
+import com.datadog.kmp.ktor.RUM_RULE_PSR
+import com.datadog.kmp.ktor.RUM_SPAN_ID
+import com.datadog.kmp.ktor.RUM_TRACE_ID
+import com.datadog.kmp.ktor.RumResourceAttributesProvider
+import com.datadog.kmp.ktor.TracingHeaderType
+import com.datadog.kmp.ktor.internal.trace.SpanId
+import com.datadog.kmp.ktor.internal.trace.SpanIdGenerator
+import com.datadog.kmp.ktor.internal.trace.TraceId
+import com.datadog.kmp.ktor.internal.trace.TraceIdGenerator
+import com.datadog.kmp.ktor.sampling.Sampler
+import com.datadog.kmp.rum.RumMonitor
+import com.datadog.kmp.rum.RumResourceKind
+import com.datadog.kmp.rum.RumResourceMethod
+import com.datadog.tools.random.exhaustiveAttributes
+import com.datadog.tools.random.nullable
+import com.datadog.tools.random.randomElement
+import com.datadog.tools.random.randomEnumValues
+import com.datadog.tools.random.randomLong
+import com.datadog.tools.random.randomULong
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matching
+import dev.mokkery.mock
+import dev.mokkery.verify
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.ConnectTimeoutException
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.request
+import io.ktor.client.request.url
+import io.ktor.client.statement.request
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class DatadogKtorPluginTest {
+
+    private val fakeHost = "datadoghq.com"
+    private val fakeTracingHeaderTypes = randomEnumValues<TracingHeaderType>()
+    private val mockRumMonitor = mock<RumMonitor>()
+    private val fakeTracedHosts = mapOf(
+        fakeHost to fakeTracingHeaderTypes
+    )
+    private val mockTraceSampler = mock<Sampler>()
+    private val mockTraceIdGenerator = mock<TraceIdGenerator>()
+    private val mockSpanIdGenerator = mock<SpanIdGenerator>()
+    private val mockRumResourceAttributesProvider = mock<RumResourceAttributesProvider>()
+
+    private val fakeSpanId = SpanId(randomULong())
+    private val fakeTraceId = TraceId(high = randomULong(), low = randomULong())
+
+    private val fakeRumRequestAttributes = exhaustiveAttributes()
+    private val fakeRumResponseAttributes = exhaustiveAttributes()
+    private val fakeRumErrorAttributes = exhaustiveAttributes()
+
+    private var testedPlugin = DatadogKtorPlugin(
+        rumMonitor = mockRumMonitor,
+        tracedHosts = fakeTracedHosts,
+        traceSampler = mockTraceSampler,
+        traceIdGenerator = mockTraceIdGenerator,
+        spanIdGenerator = mockSpanIdGenerator,
+        rumResourceAttributesProvider = mockRumResourceAttributesProvider
+    )
+
+    private val mockRequestHandler = mock<MockRequestHandler>()
+
+    // some classes of Ktor request-response chain cannot be mocked, because either they are final or some members
+    // are final, so using mock engine instead
+    private val fakeClient = HttpClient(
+        MockEngine(
+            MockEngineConfig().apply {
+                addHandler(mockRequestHandler)
+            }
+        )
+    ) {
+        install(testedPlugin.buildClientPlugin())
+    }
+
+    @BeforeTest
+    fun `set up`() {
+        every { mockTraceSampler.sample() } returns true
+        every { mockTraceSampler.sampleRate } returns 100f
+        every { mockTraceIdGenerator.generateTraceId() } returns fakeTraceId
+        every { mockSpanIdGenerator.generateSpanId() } returns fakeSpanId
+        with(mockRumResourceAttributesProvider) {
+            every { onRequest(any()) } returns fakeRumRequestAttributes
+            every { onResponse(any()) } returns fakeRumResponseAttributes
+            every { onError(any(), any()) } returns fakeRumErrorAttributes
+        }
+    }
+
+    // region RUM monitor
+
+    @Test
+    fun `M start + stop resource tracking W request succeeded + sampled for tracing`() {
+        // Given
+        val fakeUrl = "https://$fakeHost/track"
+        val fakeMethod = HttpMethod.DefaultMethods.randomElement()
+        val request = HttpRequestBuilder()
+            .apply {
+                url(fakeUrl)
+                headers["fake-header-name"] = "fake-header-value"
+                method = fakeMethod
+            }
+
+        val fakeStatusCode = HttpStatusCode.allStatusCodes.randomElement()
+        val fakeContextLength = nullable(randomLong())
+        everySuspend {
+            mockRequestHandler.invoke(
+                any(),
+                any()
+            )
+        } calls { (scope: MockRequestHandleScope, _: HttpRequestData) ->
+            scope.respond(
+                content = "", status = fakeStatusCode,
+                headers = Headers.build {
+                    if (fakeContextLength != null) {
+                        set(HttpHeaders.ContentLength, fakeContextLength.toString())
+                    }
+                }
+            )
+        }
+
+        // When
+        val response = runBlocking {
+            fakeClient.request(request)
+        }
+
+        // Then
+        verify {
+            // TODO RUM-6456 verify request headers
+            mockRumMonitor.startResource(
+                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                method = fakeMethod.asRumMethod(),
+                url = fakeUrl,
+                attributes = fakeRumRequestAttributes
+            )
+
+            mockRumMonitor.stopResource(
+                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                statusCode = fakeStatusCode.value,
+                kind = RumResourceKind.NATIVE,
+                size = fakeContextLength,
+                // seems capture doesn't work yet for verify blocks, so using matching instead
+                // see https://github.com/lupuuss/Mokkery/issues/65
+                attributes = matching {
+                    assertContains(it, RUM_TRACE_ID)
+                    assertContains(it, RUM_SPAN_ID)
+                    assertContains(it, RUM_RULE_PSR)
+
+                    checkNotNull(it[RUM_TRACE_ID])
+                    checkNotNull(it[RUM_SPAN_ID])
+                    checkNotNull(it[RUM_RULE_PSR])
+
+                    assertEquals(
+                        fakeRumResponseAttributes,
+                        it.toMutableMap().apply {
+                            remove(RUM_TRACE_ID)
+                            remove(RUM_SPAN_ID)
+                            remove(RUM_RULE_PSR)
+                        }
+                    )
+                    true
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `M start + stop resource tracking W request succeeded + not sampled for tracing`() {
+        // Given
+        every { mockTraceSampler.sample() } returns false
+        val fakeUrl = "https://$fakeHost/track"
+        val fakeMethod = HttpMethod.DefaultMethods.randomElement()
+        val request = HttpRequestBuilder()
+            .apply {
+                url(fakeUrl)
+                headers["fake-header-name"] = "fake-header-value"
+                method = fakeMethod
+            }
+
+        val fakeStatusCode = HttpStatusCode.allStatusCodes.randomElement()
+        val fakeContextLength = nullable(randomLong())
+        everySuspend {
+            mockRequestHandler.invoke(
+                any(),
+                any()
+            )
+        } calls { (scope: MockRequestHandleScope, _: HttpRequestData) ->
+            scope.respond(
+                content = "", status = fakeStatusCode,
+                headers = Headers.build {
+                    if (fakeContextLength != null) {
+                        set(HttpHeaders.ContentLength, fakeContextLength.toString())
+                    }
+                }
+            )
+        }
+
+        // When
+        val response = runBlocking {
+            fakeClient.request(request)
+        }
+
+        // Then
+        verify {
+            // TODO RUM-6456 verify request headers
+            mockRumMonitor.startResource(
+                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                method = fakeMethod.asRumMethod(),
+                url = fakeUrl,
+                attributes = fakeRumRequestAttributes
+            )
+
+            mockRumMonitor.stopResource(
+                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                statusCode = fakeStatusCode.value,
+                kind = RumResourceKind.NATIVE,
+                size = fakeContextLength,
+                attributes = fakeRumResponseAttributes
+            )
+        }
+    }
+
+    @Test
+    fun `M start + stop resource tracking with error W request failed with exception`() {
+        // Given
+        val fakeUrl = "https://$fakeHost/track"
+        val fakeMethod = HttpMethod.DefaultMethods.randomElement()
+        val request = HttpRequestBuilder()
+            .apply {
+                url(fakeUrl)
+                headers["fake-header-name"] = "fake-header-value"
+                method = fakeMethod
+            }
+        val fakeThrowable = ConnectTimeoutException(fakeUrl, timeout = randomLong())
+        everySuspend {
+            mockRequestHandler.invoke(
+                any(),
+                any()
+            )
+        } calls { (_: MockRequestHandleScope, _: HttpRequestData) ->
+            throw fakeThrowable
+        }
+
+        // When
+        try {
+            runBlocking {
+                fakeClient.request(request)
+            }
+        } catch (t: Throwable) {
+            assertEquals(fakeThrowable, t)
+        }
+
+        // Then
+        verify {
+            // TODO RUM-6456 verify request headers
+            mockRumMonitor.startResource(
+                key = any(),
+                method = fakeMethod.asRumMethod(),
+                url = fakeUrl,
+                attributes = fakeRumRequestAttributes
+            )
+
+            // TODO RUM-6456 verify request headers
+            mockRumMonitor.stopResourceWithError(
+                key = any(),
+                statusCode = null,
+                message = "Ktor request error $fakeMethod $fakeUrl",
+                throwable = fakeThrowable,
+                attributes = fakeRumErrorAttributes
+            )
+        }
+    }
+
+    // endregion
+
+    // region Host matching
+
+    @Test
+    fun `M match host W traceHeaderTypesForHost + exact host`() {
+        // When
+        val traceHeaderTypes = testedPlugin.traceHeaderTypesForHost(fakeHost)
+
+        // Then
+        assertEquals(fakeTracingHeaderTypes, traceHeaderTypes)
+    }
+
+    @Test
+    fun `M match host W traceHeaderTypesForHost + subdomain`() {
+        // When
+        val traceHeaderTypes = testedPlugin.traceHeaderTypesForHost("sub-a.sub-b.$fakeHost")
+
+        // Then
+        assertEquals(fakeTracingHeaderTypes, traceHeaderTypes)
+    }
+
+    @Test
+    fun `M match host W traceHeaderTypesForHost + match any wildcard`() {
+        // Given
+        val fakeWildcardTracHeaderTypes = randomEnumValues<TracingHeaderType>()
+        val plugin = DatadogKtorPlugin(
+            rumMonitor = mockRumMonitor,
+            tracedHosts = fakeTracedHosts + mapOf("*" to fakeWildcardTracHeaderTypes),
+            traceSampler = mockTraceSampler,
+            traceIdGenerator = mockTraceIdGenerator,
+            spanIdGenerator = mockSpanIdGenerator,
+            rumResourceAttributesProvider = mockRumResourceAttributesProvider
+        )
+
+        // When
+        val traceHeaderTypes = plugin.traceHeaderTypesForHost("random-domain.com")
+
+        // Then
+        assertEquals(fakeWildcardTracHeaderTypes, traceHeaderTypes)
+    }
+
+    // endregion
+
+    // region private
+
+    // not the same as in production files
+    private fun HttpMethod.asRumMethod() =
+        RumResourceMethod.entries.firstOrNull { it.name == value } ?: RumResourceMethod.CONNECT
+
+    // endregion
+}

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/network/NetworkClient.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/network/NetworkClient.kt
@@ -6,20 +6,24 @@
 
 package com.datadog.kmp.sample.network
 
+import com.datadog.kmp.ktor.RumResourceAttributesProvider
 import com.datadog.kmp.ktor.TracingHeaderType
 import com.datadog.kmp.ktor.datadogKtorPlugin
 import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 
-@Suppress("TooGenericExceptionCaught")
 object NetworkClient {
+
+    private const val CUSTOM_HEADER_NAME = "x-custom-header"
 
     private val client = HttpClient {
         followRedirects = true
@@ -28,7 +32,17 @@ object NetworkClient {
                 tracedHosts = mapOf(
                     "httpbin.org" to setOf(TracingHeaderType.DATADOG)
                 ),
-                traceSamplingRate = 100f
+                traceSamplingRate = 100f,
+                rumResourceAttributesProvider = object : RumResourceAttributesProvider {
+                    override fun onRequest(request: HttpRequestData) =
+                        mapOf("custom-header-value" to request.headers[CUSTOM_HEADER_NAME])
+
+                    override fun onResponse(response: HttpResponse) =
+                        mapOf("http-protocol-version" to response.version.toString())
+
+                    override fun onError(request: HttpRequestData, throwable: Throwable) =
+                        mapOf("custom-header-value" to request.headers[CUSTOM_HEADER_NAME])
+                }
             )
         )
     }
@@ -40,14 +54,16 @@ object NetworkClient {
     ) {
         withContext(Dispatchers.IO) {
             try {
-                val response = client.get(url)
+                val response = client.get(url) {
+                    headers[CUSTOM_HEADER_NAME] = "some-get-value"
+                }
                 if (response.status.value >= HttpStatusCode.BadRequest.value) {
                     onFailure(response.status.value, null)
                 } else {
                     val responseBody = response.bodyAsText()
                     onSuccess(responseBody)
                 }
-            } catch (e: Exception) {
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 onFailure(0, e)
             }
         }
@@ -63,6 +79,7 @@ object NetworkClient {
             try {
                 val response = client.post(url) {
                     setBody(payload)
+                    headers[CUSTOM_HEADER_NAME] = "some-post-value"
                 }
                 if (response.status.value >= HttpStatusCode.BadRequest.value) {
                     onFailure(response.status.value, null)
@@ -70,7 +87,7 @@ object NetworkClient {
                     val responseBody = response.bodyAsText()
                     onSuccess(responseBody)
                 }
-            } catch (e: Exception) {
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 onFailure(0, e)
             }
         }

--- a/tools/unit/src/commonMain/kotlin/com/datadog/tools/random/RandomUtils.kt
+++ b/tools/unit/src/commonMain/kotlin/com/datadog/tools/random/RandomUtils.kt
@@ -9,6 +9,7 @@
 package com.datadog.tools.random
 
 import kotlin.random.Random
+import kotlin.random.nextULong
 
 /**
  * Set of methods generating random value. NB: Use `Forge` if writing JVM/Android-specific test.
@@ -22,12 +23,22 @@ fun randomFloat(from: Float = -Float.MAX_VALUE, until: Float = Float.MAX_VALUE):
 fun randomLong(from: Long = Long.MIN_VALUE, until: Long = Long.MAX_VALUE): Long =
     Random.nextLong(from, until)
 
+fun randomULong(from: ULong = ULong.MIN_VALUE, until: ULong = ULong.MAX_VALUE): ULong =
+    Random.nextULong(from, until)
+
 fun randomInt(from: Int = Int.MIN_VALUE, until: Int = Int.MAX_VALUE): Int =
     Random.nextInt(from, until)
 
 inline fun <reified T : Enum<T>> randomEnumValue(): T {
     val values = enumValues<T>()
     return values[Random.nextInt(values.size)]
+}
+
+inline fun <reified T : Enum<T>> randomEnumValues(): Set<T> {
+    val values = enumValues<T>()
+    values.shuffle()
+
+    return values.take(randomInt(from = 1, until = values.size)).toSet()
 }
 
 fun exhaustiveAttributes(): Map<String, Any?> {


### PR DESCRIPTION
### What does this PR do?

This PR adds support of RUM Resource attributes provider, allowing to add additional attributes to RUM Resources based on the request/response/error from Ktor call chain.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

