### PR TITLE
Avoid using `HttpRequestData` for resource attributes collection in Ktor instrumentation

### DIFF
--- a/integrations/ktor/api/commonMain/apiSurface
+++ b/integrations/ktor/api/commonMain/apiSurface
@@ -3,9 +3,10 @@ const val RUM_TRACE_ID: String
 const val RUM_SPAN_ID: String
 const val RUM_RULE_PSR: String
 interface com.datadog.kmp.ktor.RumResourceAttributesProvider
-  fun onRequest(io.ktor.client.request.HttpRequestData): Map<String, Any?>
+  fun onRequest(HttpRequestSnapshot): Map<String, Any?>
   fun onResponse(io.ktor.client.statement.HttpResponse): Map<String, Any?>
-  fun onError(io.ktor.client.request.HttpRequestData, Throwable): Map<String, Any?>
+  fun onError(HttpRequestSnapshot, Throwable): Map<String, Any?>
+class com.datadog.kmp.ktor.HttpRequestSnapshot
 enum com.datadog.kmp.ktor.TracingHeaderType
   - DATADOG
   - B3

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/RumResourceAttributesProvider.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/RumResourceAttributesProvider.kt
@@ -7,11 +7,17 @@
 package com.datadog.kmp.ktor
 
 import io.ktor.client.request.HttpRequest
-import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
+import io.ktor.http.Headers
+import io.ktor.http.HttpMethod
+import io.ktor.http.Url
+import io.ktor.http.clone
+import io.ktor.util.Attributes
+import io.ktor.util.putAll
 
 /**
- * Provider which listens for the Ktor [HttpRequestData] -> [HttpResponse] (or [Throwable]) chain and
+ * Provider which listens for the Ktor [HttpRequestSnapshot] -> [HttpResponse] (or [Throwable]) chain and
  * offers a possibility to add custom attributes to the RUM Resource event.
  */
 interface RumResourceAttributesProvider {
@@ -19,9 +25,9 @@ interface RumResourceAttributesProvider {
     /**
      * Offers a possibility to provide custom attributes at the request creation stage, which later will be attached
      * the RUM resource event associated with the request.
-     * @param request the intercepted [HttpRequestData]
+     * @param request the intercepted [HttpRequestSnapshot]
      */
-    fun onRequest(request: HttpRequestData): Map<String, Any?>
+    fun onRequest(request: HttpRequestSnapshot): Map<String, Any?>
 
     /**
      * Offers a possibility to create custom attributes at the response receive stage, which later will be attached to
@@ -33,14 +39,42 @@ interface RumResourceAttributesProvider {
     /**
      * Offers a possibility to create custom attributes at the error receive stage, which later will be attached to
      * the RUM resource event associated with the request.
-     * @param request the intercepted [HttpRequestData]
+     * @param request the intercepted [HttpRequestSnapshot]
      * @param throwable in case an error occurred during the [HttpRequest]
      */
-    fun onError(request: HttpRequestData, throwable: Throwable): Map<String, Any?>
+    fun onError(request: HttpRequestSnapshot, throwable: Throwable): Map<String, Any?>
+}
+
+/**
+ * Represents an immutable snapshot of the request to be executed.
+ *
+ * @param url the [Url] to be called.
+ * @param method the [HttpMethod] to be used.
+ * @param headers the [Headers] to be used.
+ * @param body the body of the request (if any). Note: it is a raw body, before any content transformation is applied.
+ * @param attributes the [Attributes] of the request.
+ */
+class HttpRequestSnapshot internal constructor(
+    val url: Url,
+    val method: HttpMethod,
+    val headers: Headers,
+    val body: Any,
+    val attributes: Attributes
+) {
+    internal companion object {
+        fun takeFrom(builder: HttpRequestBuilder) = HttpRequestSnapshot(
+            // build() mutates the builder, so using clone to have a separate copy
+            url = builder.url.clone().build(),
+            method = builder.method,
+            headers = builder.headers.build(),
+            body = builder.body,
+            attributes = Attributes().apply { putAll(builder.attributes) }
+        )
+    }
 }
 
 internal object DefaultRumResourceAttributesProvider : RumResourceAttributesProvider {
-    override fun onRequest(request: HttpRequestData) = emptyMap<String, Any?>()
+    override fun onRequest(request: HttpRequestSnapshot) = emptyMap<String, Any?>()
     override fun onResponse(response: HttpResponse) = emptyMap<String, Any?>()
-    override fun onError(request: HttpRequestData, throwable: Throwable) = emptyMap<String, Any?>()
+    override fun onError(request: HttpRequestSnapshot, throwable: Throwable) = emptyMap<String, Any?>()
 }

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
@@ -7,6 +7,7 @@
 package com.datadog.kmp.ktor.internal.plugin
 
 import com.benasher44.uuid.uuid4
+import com.datadog.kmp.ktor.HttpRequestSnapshot
 import com.datadog.kmp.ktor.RUM_RULE_PSR
 import com.datadog.kmp.ktor.RUM_SPAN_ID
 import com.datadog.kmp.ktor.RUM_TRACE_ID
@@ -65,7 +66,7 @@ internal class DatadogKtorPlugin(
             key = requestId,
             method = request.method.asRumMethod(),
             url = request.url.buildString(),
-            attributes = rumResourceAttributesProvider.onRequest(request.build())
+            attributes = rumResourceAttributesProvider.onRequest(HttpRequestSnapshot.takeFrom(builder = request))
         )
     }
 
@@ -105,7 +106,10 @@ internal class DatadogKtorPlugin(
                 statusCode = null,
                 message = "Ktor request error $method $url",
                 throwable = throwable,
-                attributes = rumResourceAttributesProvider.onError(request.build(), throwable)
+                attributes = rumResourceAttributesProvider.onError(
+                    HttpRequestSnapshot.takeFrom(builder = request),
+                    throwable
+                )
             )
         } else {
             // TODO RUM-5254 handle missing request id case

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
@@ -43,12 +43,15 @@ import io.ktor.client.plugins.ConnectTimeoutException
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.request
+import io.ktor.client.request.setBody
 import io.ktor.client.request.url
 import io.ktor.client.statement.request
+import io.ktor.http.ContentType
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
 import kotlinx.coroutines.runBlocking
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -123,6 +126,12 @@ class DatadogKtorPluginTest {
                 url(fakeUrl)
                 headers["fake-header-name"] = "fake-header-value"
                 method = fakeMethod
+                if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
+                    setBody(
+                        listOf("body", TextContent("body", ContentType.Any))
+                            .randomElement()
+                    )
+                }
             }
 
         val fakeStatusCode = HttpStatusCode.allStatusCodes.randomElement()
@@ -199,6 +208,12 @@ class DatadogKtorPluginTest {
                 url(fakeUrl)
                 headers["fake-header-name"] = "fake-header-value"
                 method = fakeMethod
+                if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
+                    setBody(
+                        listOf("body", TextContent("body", ContentType.Any))
+                            .randomElement()
+                    )
+                }
             }
 
         val fakeStatusCode = HttpStatusCode.allStatusCodes.randomElement()
@@ -254,6 +269,12 @@ class DatadogKtorPluginTest {
                 url(fakeUrl)
                 headers["fake-header-name"] = "fake-header-value"
                 method = fakeMethod
+                if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
+                    setBody(
+                        listOf("body", TextContent("body", ContentType.Any))
+                            .randomElement()
+                    )
+                }
             }
         val fakeThrowable = ConnectTimeoutException(fakeUrl, timeout = randomLong())
         everySuspend {

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/network/NetworkClient.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/network/NetworkClient.kt
@@ -6,11 +6,11 @@
 
 package com.datadog.kmp.sample.network
 
+import com.datadog.kmp.ktor.HttpRequestSnapshot
 import com.datadog.kmp.ktor.RumResourceAttributesProvider
 import com.datadog.kmp.ktor.TracingHeaderType
 import com.datadog.kmp.ktor.datadogKtorPlugin
 import io.ktor.client.HttpClient
-import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -34,13 +34,13 @@ object NetworkClient {
                 ),
                 traceSamplingRate = 100f,
                 rumResourceAttributesProvider = object : RumResourceAttributesProvider {
-                    override fun onRequest(request: HttpRequestData) =
+                    override fun onRequest(request: HttpRequestSnapshot) =
                         mapOf("custom-header-value" to request.headers[CUSTOM_HEADER_NAME])
 
                     override fun onResponse(response: HttpResponse) =
                         mapOf("http-protocol-version" to response.version.toString())
 
-                    override fun onError(request: HttpRequestData, throwable: Throwable) =
+                    override fun onError(request: HttpRequestSnapshot, throwable: Throwable) =
                         mapOf("custom-header-value" to request.headers[CUSTOM_HEADER_NAME])
                 }
             )


### PR DESCRIPTION
### What does this PR do?

`HttpRequestBuilder.build()` has a requirement that `body` should be an instance of `OutgoingContent` ([link](https://github.com/ktorio/ktor/blob/6d26bc9c589e10cbbc5fb1e4787c8b09c329f9fc/ktor-client/ktor-client-core/common/src/io/ktor/client/request/HttpRequest.kt#L121)).

This will be the case only once `Render` pipeline stage is hit, but our `onRequest` is called earlier.

So in this PR we are building the current state of the request manually, supplying raw body before any transformations.

We could provide `HttpRequestBuilder` instead, but in the `RumResourceAttributesProvider` callbacks we want to make it clear that the value provided is expected to mutate.

Maybe, in the future, we should use `on(Send)` instead of `onRequest`, because it is called on the final pipeline stage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

