### PR TITLE
Pin CodeQL bundle version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,6 +38,8 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
+        # temporary pinning version, because newer versions are using CodeQL bundle 2.20.0, which crashes
+        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.19.4/codeql-bundle-linux64.tar.zst
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.


### PR DESCRIPTION
### What does this PR do?

This PR pins CodeQL bundle version, because newer versions are using CodeQL bundle which is crashing by some reason with the following error during the analysis:

```
CodeQL detected code written in Java/Kotlin but could not process any of it
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

