### PR TITLE
RUM-7677: Add Session Replay `startRecordingImmediately` configuration API

### DIFF
--- a/features/session-replay/api/commonMain/apiSurface
+++ b/features/session-replay/api/commonMain/apiSurface
@@ -13,6 +13,7 @@ data class com.datadog.kmp.sessionreplay.configuration.SessionReplayConfiguratio
     fun setImagePrivacy(ImagePrivacy): Builder
     fun setTouchPrivacy(TouchPrivacy): Builder
     fun setTextAndInputPrivacy(TextAndInputPrivacy): Builder
+    fun startRecordingImmediately(Boolean): Builder
     fun build(): SessionReplayConfiguration
 enum com.datadog.kmp.sessionreplay.configuration.SessionReplayPrivacy
   - ALLOW

--- a/features/session-replay/src/androidMain/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/AndroidSessionReplayConfigurationBuilder.kt
+++ b/features/session-replay/src/androidMain/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/AndroidSessionReplayConfigurationBuilder.kt
@@ -59,6 +59,10 @@ internal class AndroidSessionReplayConfigurationBuilder :
         nativeBuilder.setTextAndInputPrivacy(privacy.native)
     }
 
+    override fun startRecordingImmediately(enabled: Boolean) {
+        nativeBuilder.startRecordingImmediately(enabled)
+    }
+
     override fun build(): SessionReplayConfiguration {
         return nativeBuilder.build()
     }

--- a/features/session-replay/src/androidUnitTest/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/AndroidSessionReplayConfigurationBuilderTest.kt
+++ b/features/session-replay/src/androidUnitTest/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/AndroidSessionReplayConfigurationBuilderTest.kt
@@ -132,6 +132,17 @@ class AndroidSessionReplayConfigurationBuilderTest {
     }
 
     @Test
+    fun `M call platform configuration builder+startRecordingImmediately W startRecordingImmediately`(
+        @BoolForgery fakeEnabled: Boolean
+    ) {
+        // When
+        testedBuilder.startRecordingImmediately(fakeEnabled)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).startRecordingImmediately(fakeEnabled)
+    }
+
+    @Test
     fun `M call platform configuration builder+build W build`() {
         // Given
         val mockNativeConfiguration = mock<NativeSessionReplayConfiguration>()

--- a/features/session-replay/src/commonMain/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfiguration.kt
+++ b/features/session-replay/src/commonMain/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfiguration.kt
@@ -86,6 +86,16 @@ data class SessionReplayConfiguration internal constructor(
         }
 
         /**
+         * Should recording start automatically (or be manually started).
+         * If not specified then by default it starts automatically.
+         * @param enabled whether recording should start automatically or not.
+         */
+        fun startRecordingImmediately(enabled: Boolean): Builder {
+            platformBuilder.startRecordingImmediately(enabled)
+            return this
+        }
+
+        /**
          * Builds a [SessionReplayConfiguration] based on the current state of this Builder.
          */
         fun build(): SessionReplayConfiguration {

--- a/features/session-replay/src/commonMain/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/PlatformSessionReplayConfigurationBuilder.kt
+++ b/features/session-replay/src/commonMain/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/PlatformSessionReplayConfigurationBuilder.kt
@@ -21,5 +21,7 @@ internal interface PlatformSessionReplayConfigurationBuilder<T : Any> {
 
     fun setTextAndInputPrivacy(privacy: TextAndInputPrivacy)
 
+    fun startRecordingImmediately(enabled: Boolean)
+
     fun build(): T
 }

--- a/features/session-replay/src/commonTest/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfigurationBuilderTest.kt
+++ b/features/session-replay/src/commonTest/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfigurationBuilderTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.kmp.sessionreplay.configuration
 
 import com.datadog.kmp.sessionreplay.configuration.internal.PlatformSessionReplayConfigurationBuilder
+import com.datadog.tools.random.randomBoolean
 import com.datadog.tools.random.randomEnumValue
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -89,6 +90,20 @@ class SessionReplayConfigurationBuilderTest {
         // Then
         verify {
             mockPlatformSessionReplayConfigurationBuilder.setTextAndInputPrivacy(fakeTextAndInputPrivacy)
+        }
+    }
+
+    @Test
+    fun `M call platform configuration builder+startRecordingImmediately W startRecordingImmediately`() {
+        // Given
+        val fakeEnabled = randomBoolean()
+
+        // When
+        testedSessionReplayConfigurationBuilder.startRecordingImmediately(fakeEnabled)
+
+        // Then
+        verify {
+            mockPlatformSessionReplayConfigurationBuilder.startRecordingImmediately(fakeEnabled)
         }
     }
 }

--- a/features/session-replay/src/iosMain/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/IOSSessionReplayConfigurationBuilder.kt
+++ b/features/session-replay/src/iosMain/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/IOSSessionReplayConfigurationBuilder.kt
@@ -48,6 +48,10 @@ internal class IOSSessionReplayConfigurationBuilder(sampleRate: Float) :
         nativeConfiguration.setTextAndInputPrivacyLevel(privacy.native)
     }
 
+    override fun startRecordingImmediately(enabled: Boolean) {
+        nativeConfiguration.setStartRecordingImmediately(enabled)
+    }
+
     override fun build(): DDSessionReplayConfiguration {
         return nativeConfiguration
     }

--- a/features/session-replay/src/iosTest/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/IOSSessionReplayConfigurationBuilderTest.kt
+++ b/features/session-replay/src/iosTest/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/IOSSessionReplayConfigurationBuilderTest.kt
@@ -25,6 +25,7 @@ import com.datadog.kmp.sessionreplay.configuration.ImagePrivacy
 import com.datadog.kmp.sessionreplay.configuration.SessionReplayPrivacy
 import com.datadog.kmp.sessionreplay.configuration.TextAndInputPrivacy
 import com.datadog.kmp.sessionreplay.configuration.TouchPrivacy
+import com.datadog.tools.random.randomBoolean
 import com.datadog.tools.random.randomEnumValue
 import com.datadog.tools.random.randomFloat
 import kotlin.test.BeforeTest
@@ -97,6 +98,21 @@ class IOSSessionReplayConfigurationBuilderTest {
         assertEquals(
             fakeTextAndInputPrivacy.native,
             testedConfigurationBuilder.nativeConfiguration.textAndInputPrivacyLevel()
+        )
+    }
+
+    @Test
+    fun `M call platform configuration builder+setStartRecordingImmediately W startRecordingImmediately`() {
+        // Given
+        val fakeEnabled = randomBoolean()
+
+        // When
+        testedConfigurationBuilder.startRecordingImmediately(fakeEnabled)
+
+        // Then
+        assertEquals(
+            fakeEnabled,
+            testedConfigurationBuilder.nativeConfiguration.startRecordingImmediately()
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds support of `SessionReplayConfiguration#startRecordingImmediately` API.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

