### PR TITLE
Disable Gradle build cache for CodeQL job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,8 @@ jobs:
 
     # Manually build the java bytecode
     - name: Execute Gradle build
-      run: ./gradlew assembleRelease
+      # disable build caching, otherwise CodeQL cannot properly pick output, it seems
+      run: ./gradlew assembleRelease --no-build-cache
 
     # Perform the analysis
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
### What does this PR do?

CodeQL sometime gives the following error:

```
CodeQL detected code written in Java/Kotlin but could not process any of it
```

It may be related to the build caching in Gradle.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

