### PR TITLE
RUM-7625: Support redirects in Ktor instrumentation

### DIFF
--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaders.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaders.kt
@@ -39,6 +39,6 @@ internal const val W3C_SAMPLING_DECISION_INDEX = 3
 internal const val W3C_TRACE_ID_LENGTH = 32
 internal const val W3C_PARENT_ID_LENGTH = 16
 internal const val W3C_SAMPLE_PRIORITY_ACCEPT = "01"
-internal const val W3C_SAMPLE_PRIORITY_DROP = "01"
+internal const val W3C_SAMPLE_PRIORITY_DROP = "00"
 
 internal const val HEX_RADIX: Int = 16

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/KtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/KtorPlugin.kt
@@ -10,17 +10,27 @@ import io.ktor.client.plugins.api.OnRequestContext
 import io.ktor.client.plugins.api.OnResponseContext
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
+import io.ktor.http.content.OutgoingContent
 
 internal interface KtorPlugin {
 
     val pluginName: String
 
+    // user-initiated request: doesn't include HTTP client-initiated requests (e.g. redirect) and context here is
+    // not yet transformed
     fun onRequest(
         onRequestContext: OnRequestContext,
         request: HttpRequestBuilder,
         content: Any
     )
 
+    // will be called on any request (both user-initiated and ktor-initiated)
+    fun onSend(
+        request: HttpRequestBuilder,
+        content: OutgoingContent
+    )
+
+    // will be called on any response (both user-initiated and ktor-initiated)
     fun onResponse(
         onResponseContext: OnResponseContext,
         response: HttpResponse

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.kmp.ktor.internal.plugin
 
+import com.datadog.kmp.ktor.HEX_RADIX
 import com.datadog.kmp.ktor.RUM_RULE_PSR
 import com.datadog.kmp.ktor.RUM_SPAN_ID
 import com.datadog.kmp.ktor.RUM_TRACE_ID
@@ -16,20 +17,25 @@ import com.datadog.kmp.ktor.internal.trace.SpanIdGenerator
 import com.datadog.kmp.ktor.internal.trace.TraceId
 import com.datadog.kmp.ktor.internal.trace.TraceIdGenerator
 import com.datadog.kmp.ktor.sampling.Sampler
+import com.datadog.kmp.ktor.test.HeadersAssert.Companion.assertThat
 import com.datadog.kmp.rum.RumMonitor
 import com.datadog.kmp.rum.RumResourceKind
 import com.datadog.kmp.rum.RumResourceMethod
 import com.datadog.tools.random.exhaustiveAttributes
 import com.datadog.tools.random.nullable
+import com.datadog.tools.random.randomBoolean
 import com.datadog.tools.random.randomElement
 import com.datadog.tools.random.randomEnumValues
+import com.datadog.tools.random.randomFloat
 import com.datadog.tools.random.randomLong
 import com.datadog.tools.random.randomULong
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsBy
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.collections.isIn
 import dev.mokkery.matcher.matching
 import dev.mokkery.mock
 import dev.mokkery.verify
@@ -42,6 +48,7 @@ import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.MockRequestHandler
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.ConnectTimeoutException
+import io.ktor.client.request.HttpRequest
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.request
@@ -59,22 +66,19 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class DatadogKtorPluginTest {
 
     private val fakeHost = "datadoghq.com"
     private val fakeTracingHeaderTypes = randomEnumValues<TracingHeaderType>()
     private val mockRumMonitor = mock<RumMonitor>()
-    private val fakeTracedHosts = mapOf(
-        fakeHost to fakeTracingHeaderTypes
-    )
+    private val fakeTracedHosts = mapOf(fakeHost to fakeTracingHeaderTypes)
     private val mockTraceSampler = mock<Sampler>()
     private val mockTraceIdGenerator = mock<TraceIdGenerator>()
     private val mockSpanIdGenerator = mock<SpanIdGenerator>()
     private val mockRumResourceAttributesProvider = mock<RumResourceAttributesProvider>()
-
-    private val fakeSpanId = SpanId(randomULong())
-    private val fakeTraceId = TraceId(high = randomULong(), low = randomULong())
 
     private val fakeRumRequestAttributes = exhaustiveAttributes()
     private val fakeRumResponseAttributes = exhaustiveAttributes()
@@ -90,16 +94,15 @@ class DatadogKtorPluginTest {
     )
 
     private val mockRequestHandler = mock<MockRequestHandler>()
+    private val mockEngine = MockEngine(
+        MockEngineConfig().apply {
+            addHandler(mockRequestHandler)
+        }
+    )
 
     // some classes of Ktor request-response chain cannot be mocked, because either they are final or some members
     // are final, so using mock engine instead
-    private val fakeClient = HttpClient(
-        MockEngine(
-            MockEngineConfig().apply {
-                addHandler(mockRequestHandler)
-            }
-        )
-    ) {
+    private val fakeClient = HttpClient(mockEngine) {
         install(testedPlugin.buildClientPlugin())
     }
 
@@ -107,8 +110,13 @@ class DatadogKtorPluginTest {
     fun `set up`() {
         every { mockTraceSampler.sample() } returns true
         every { mockTraceSampler.sampleRate } returns 100f
-        every { mockTraceIdGenerator.generateTraceId() } returns fakeTraceId
-        every { mockSpanIdGenerator.generateSpanId() } returns fakeSpanId
+        every { mockTraceIdGenerator.generateTraceId() } returnsBy {
+            TraceId(
+                high = randomULong(),
+                low = randomULong()
+            )
+        }
+        every { mockSpanIdGenerator.generateSpanId() } returnsBy { SpanId(randomULong()) }
         with(mockRumResourceAttributesProvider) {
             every { onRequest(any()) } returns fakeRumRequestAttributes
             every { onResponse(any()) } returns fakeRumResponseAttributes
@@ -128,12 +136,7 @@ class DatadogKtorPluginTest {
                 url(fakeUrl)
                 headers["fake-header-name"] = "fake-header-value"
                 method = fakeMethod
-                if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
-                    setBody(
-                        listOf("body", TextContent("body", ContentType.Any))
-                            .randomElement()
-                    )
-                }
+                setRandomBody()
             }
 
         val fakeStatusCode = HttpStatusCode.allStatusCodes
@@ -141,10 +144,7 @@ class DatadogKtorPluginTest {
             .randomElement()
         val fakeContextLength = nullable(randomLong())
         everySuspend {
-            mockRequestHandler.invoke(
-                any(),
-                any()
-            )
+            mockRequestHandler.invoke(any(), any())
         } calls { (scope: MockRequestHandleScope, _: HttpRequestData) ->
             scope.respond(
                 content = "",
@@ -163,17 +163,17 @@ class DatadogKtorPluginTest {
         }
 
         // Then
-        verify {
-            // TODO RUM-6456 verify request headers
+        val capturedRequestHeaders = mockEngine.requestHistory.map { it.headers }
+        verify(VerifyMode.exhaustiveOrder) {
             mockRumMonitor.startResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = response.request.requestId,
                 method = fakeMethod.asRumMethod(),
                 url = fakeUrl,
                 attributes = fakeRumRequestAttributes
             )
 
             mockRumMonitor.stopResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = response.request.requestId,
                 statusCode = fakeStatusCode.value,
                 kind = RumResourceKind.NATIVE,
                 size = fakeContextLength,
@@ -184,9 +184,19 @@ class DatadogKtorPluginTest {
                     assertContains(it, RUM_SPAN_ID)
                     assertContains(it, RUM_RULE_PSR)
 
-                    checkNotNull(it[RUM_TRACE_ID])
-                    checkNotNull(it[RUM_SPAN_ID])
-                    checkNotNull(it[RUM_RULE_PSR])
+                    val traceId = checkNotNull(it[RUM_TRACE_ID] as? String)
+                    val spanId = checkNotNull(it[RUM_SPAN_ID] as? String)
+                    val rulePsr = checkNotNull(it[RUM_RULE_PSR] as? Float)
+
+                    assertEquals(1f, rulePsr)
+                    assertThat(capturedRequestHeaders.first())
+                        .apply {
+                            fakeTracingHeaderTypes.forEach {
+                                hasTraceId(expectedTraceId(traceId, it), it)
+                                hasSpanId(expectedSpanId(spanId, it), it)
+                                hasSamplingDecision(1, it)
+                            }
+                        }
 
                     assertEquals(
                         fakeRumResponseAttributes,
@@ -204,26 +214,16 @@ class DatadogKtorPluginTest {
         verifyNoMoreCalls(mockRumMonitor)
     }
 
-    // TODO RUM-7625 Redirect tracking is wrong: first redirect response will stop resource and it won't be any
-    //  new `onRequest` call. See ticket for more details.
     @Test
     fun `M start + stop resource tracking W request succeeded + sampled for tracing + redirect`() {
         // Given
         val fakeUrl = "https://$fakeHost/track"
-        // Only Get and Head are allowed for implicit redirect, see Ktor HttpRedirect.kt
-        val fakeMethod = listOf(HttpMethod.Get, HttpMethod.Head)
-            .randomElement()
+        val fakeMethod = randomRedirectMethod()
         val request = HttpRequestBuilder()
             .apply {
                 url(fakeUrl)
                 headers["fake-header-name"] = "fake-header-value"
                 method = fakeMethod
-                if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
-                    setBody(
-                        listOf("body", TextContent("body", ContentType.Any))
-                            .randomElement()
-                    )
-                }
             }
 
         val fakeStatusCode = HttpStatusCode.allStatusCodes
@@ -232,23 +232,17 @@ class DatadogKtorPluginTest {
         val fakeRedirectStatusCode = HttpStatusCode.redirectStatusCodes()
             .randomElement()
         val fakeContextLength = nullable(randomLong())
-        var redirected = false
         everySuspend {
-            mockRequestHandler.invoke(
-                any(),
-                any()
-            )
-        } calls { (scope: MockRequestHandleScope, _: HttpRequestData) ->
-            if (!redirected) {
+            mockRequestHandler.invoke(any(), any())
+        } calls { (scope: MockRequestHandleScope, request: HttpRequestData) ->
+            if (!request.url.encodedPath.endsWith("/redirected")) {
                 scope.respond(
                     content = "",
                     status = fakeRedirectStatusCode,
                     headers = Headers.build {
                         set(HttpHeaders.Location, "$fakeUrl/redirected")
                     }
-                ).also {
-                    redirected = true
-                }
+                )
             } else {
                 scope.respond(
                     content = "",
@@ -263,22 +257,32 @@ class DatadogKtorPluginTest {
         }
 
         // When
-        val response = runBlocking {
+        runBlocking {
             fakeClient.request(request)
         }
 
         // Then
+        val recordedRequests = mockEngine.requestHistory
+        val recordedResponses = mockEngine.responseHistory
+        assertEquals(2, recordedRequests.size)
+        assertEquals(2, recordedResponses.size)
+        val firstRequestId = recordedRequests[0].requestId
+        val redirectRequestId = recordedRequests[1].requestId
+        assertNotEquals(firstRequestId, redirectRequestId)
+        val capturedRequestHeaders = recordedRequests.map { it.headers }
+        assertEquals(recordedRequests[0].traceId, recordedRequests[1].traceId)
+        assertNotEquals(recordedRequests[0].spanId, recordedRequests[1].spanId)
+
         verify(VerifyMode.exhaustiveOrder) {
-            // TODO RUM-6456 verify request headers
             mockRumMonitor.startResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = firstRequestId,
                 method = fakeMethod.asRumMethod(),
                 url = fakeUrl,
                 attributes = fakeRumRequestAttributes
             )
 
             mockRumMonitor.stopResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = firstRequestId,
                 statusCode = fakeRedirectStatusCode.value,
                 kind = RumResourceKind.NATIVE,
                 size = null,
@@ -289,9 +293,19 @@ class DatadogKtorPluginTest {
                     assertContains(it, RUM_SPAN_ID)
                     assertContains(it, RUM_RULE_PSR)
 
-                    checkNotNull(it[RUM_TRACE_ID])
-                    checkNotNull(it[RUM_SPAN_ID])
-                    checkNotNull(it[RUM_RULE_PSR])
+                    val traceId = checkNotNull(it[RUM_TRACE_ID] as? String)
+                    val spanId = checkNotNull(it[RUM_SPAN_ID] as? String)
+                    val rulePsr = checkNotNull(it[RUM_RULE_PSR])
+
+                    assertEquals(1f, rulePsr)
+                    assertThat(capturedRequestHeaders.first())
+                        .apply {
+                            fakeTracingHeaderTypes.forEach {
+                                hasTraceId(expectedTraceId(traceId, it), it)
+                                hasSpanId(expectedSpanId(spanId, it), it)
+                                hasSamplingDecision(1, it)
+                            }
+                        }
 
                     assertEquals(
                         fakeRumResponseAttributes,
@@ -305,8 +319,15 @@ class DatadogKtorPluginTest {
                 }
             )
 
+            mockRumMonitor.startResource(
+                key = redirectRequestId,
+                method = fakeMethod.asRumMethod(),
+                url = "$fakeUrl/redirected",
+                attributes = fakeRumRequestAttributes
+            )
+
             mockRumMonitor.stopResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = redirectRequestId,
                 statusCode = fakeStatusCode.value,
                 kind = RumResourceKind.NATIVE,
                 size = fakeContextLength,
@@ -317,9 +338,19 @@ class DatadogKtorPluginTest {
                     assertContains(it, RUM_SPAN_ID)
                     assertContains(it, RUM_RULE_PSR)
 
-                    checkNotNull(it[RUM_TRACE_ID])
-                    checkNotNull(it[RUM_SPAN_ID])
-                    checkNotNull(it[RUM_RULE_PSR])
+                    val traceId = checkNotNull(it[RUM_TRACE_ID] as? String)
+                    val spanId = checkNotNull(it[RUM_SPAN_ID] as? String)
+                    val rulePsr = checkNotNull(it[RUM_RULE_PSR])
+
+                    assertEquals(1f, rulePsr)
+                    assertThat(capturedRequestHeaders[1])
+                        .apply {
+                            fakeTracingHeaderTypes.forEach {
+                                hasTraceId(expectedTraceId(traceId, it), it)
+                                hasSpanId(expectedSpanId(spanId, it), it)
+                                hasSamplingDecision(1, it)
+                            }
+                        }
 
                     assertEquals(
                         fakeRumResponseAttributes,
@@ -333,6 +364,8 @@ class DatadogKtorPluginTest {
                 }
             )
         }
+
+        verifyNoMoreCalls(mockRumMonitor)
     }
 
     @Test
@@ -346,12 +379,7 @@ class DatadogKtorPluginTest {
                 url(fakeUrl)
                 headers["fake-header-name"] = "fake-header-value"
                 method = fakeMethod
-                if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
-                    setBody(
-                        listOf("body", TextContent("body", ContentType.Any))
-                            .randomElement()
-                    )
-                }
+                setRandomBody()
             }
 
         val fakeStatusCode = HttpStatusCode.allStatusCodes
@@ -359,10 +387,7 @@ class DatadogKtorPluginTest {
             .randomElement()
         val fakeContextLength = nullable(randomLong())
         everySuspend {
-            mockRequestHandler.invoke(
-                any(),
-                any()
-            )
+            mockRequestHandler.invoke(any(), any())
         } calls { (scope: MockRequestHandleScope, _: HttpRequestData) ->
             scope.respond(
                 content = "",
@@ -382,45 +407,43 @@ class DatadogKtorPluginTest {
 
         // Then
         verify {
-            // TODO RUM-6456 verify request headers
             mockRumMonitor.startResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = response.request.requestId,
                 method = fakeMethod.asRumMethod(),
                 url = fakeUrl,
                 attributes = fakeRumRequestAttributes
             )
 
             mockRumMonitor.stopResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = response.request.requestId,
                 statusCode = fakeStatusCode.value,
                 kind = RumResourceKind.NATIVE,
                 size = fakeContextLength,
                 attributes = fakeRumResponseAttributes
             )
         }
+
+        verifyNoMoreCalls(mockRumMonitor)
+
+        assertThat(mockEngine.requestHistory.first().headers)
+            .apply {
+                fakeTracingHeaderTypes.forEach {
+                    hasSamplingDecision(0, it)
+                }
+            }
     }
 
-    // TODO RUM-7625 Redirect tracking is wrong: first redirect response will stop resource and it won't be any
-    //  new `onRequest` call. See ticket for more details.
     @Test
     fun `M start + stop resource tracking W request succeeded + not sampled for tracing + redirect`() {
         // Given
         every { mockTraceSampler.sample() } returns false
         val fakeUrl = "https://$fakeHost/track"
-        // Only Get and Head are allowed for implicit redirect, see Ktor HttpRedirect.kt
-        val fakeMethod = listOf(HttpMethod.Get, HttpMethod.Head)
-            .randomElement()
+        val fakeMethod = randomRedirectMethod()
         val request = HttpRequestBuilder()
             .apply {
                 url(fakeUrl)
                 headers["fake-header-name"] = "fake-header-value"
                 method = fakeMethod
-                if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
-                    setBody(
-                        listOf("body", TextContent("body", ContentType.Any))
-                            .randomElement()
-                    )
-                }
             }
 
         val fakeStatusCode = HttpStatusCode.allStatusCodes
@@ -429,23 +452,17 @@ class DatadogKtorPluginTest {
         val fakeRedirectStatusCode = HttpStatusCode.redirectStatusCodes()
             .randomElement()
         val fakeContextLength = nullable(randomLong())
-        var redirected = false
         everySuspend {
-            mockRequestHandler.invoke(
-                any(),
-                any()
-            )
-        } calls { (scope: MockRequestHandleScope, _: HttpRequestData) ->
-            if (!redirected) {
+            mockRequestHandler.invoke(any(), any())
+        } calls { (scope: MockRequestHandleScope, request: HttpRequestData) ->
+            if (!request.url.encodedPath.endsWith("/redirected")) {
                 scope.respond(
                     content = "",
                     status = fakeRedirectStatusCode,
                     headers = Headers.build {
                         set(HttpHeaders.Location, "$fakeUrl/redirected")
                     }
-                ).also {
-                    redirected = true
-                }
+                )
             } else {
                 scope.respond(
                     content = "",
@@ -460,36 +477,183 @@ class DatadogKtorPluginTest {
         }
 
         // When
-        val response = runBlocking {
+        runBlocking {
             fakeClient.request(request)
         }
 
         // Then
+        val recordedRequests = mockEngine.requestHistory
+        val recordedResponses = mockEngine.responseHistory
+        assertEquals(2, recordedRequests.size)
+        assertEquals(2, recordedResponses.size)
+        val firstRequestId = recordedRequests[0].requestId
+        val redirectRequestId = recordedRequests[1].requestId
+        assertNotEquals(firstRequestId, redirectRequestId)
+        val capturedRequestHeaders = recordedRequests.map { it.headers }
+
         verify(VerifyMode.exhaustiveOrder) {
-            // TODO RUM-6456 verify request headers
             mockRumMonitor.startResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = firstRequestId,
                 method = fakeMethod.asRumMethod(),
                 url = fakeUrl,
                 attributes = fakeRumRequestAttributes
             )
 
             mockRumMonitor.stopResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = firstRequestId,
                 statusCode = fakeRedirectStatusCode.value,
                 kind = RumResourceKind.NATIVE,
                 size = null,
                 attributes = fakeRumResponseAttributes
             )
 
+            mockRumMonitor.startResource(
+                key = redirectRequestId,
+                method = fakeMethod.asRumMethod(),
+                url = "$fakeUrl/redirected",
+                attributes = fakeRumRequestAttributes
+            )
+
             mockRumMonitor.stopResource(
-                key = response.request.attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR],
+                key = redirectRequestId,
                 statusCode = fakeStatusCode.value,
                 kind = RumResourceKind.NATIVE,
                 size = fakeContextLength,
                 attributes = fakeRumResponseAttributes
             )
         }
+
+        verifyNoMoreCalls(mockRumMonitor)
+
+        capturedRequestHeaders.forEach {
+            assertThat(it)
+                .apply {
+                    fakeTracingHeaderTypes.forEach {
+                        hasSamplingDecision(0, it)
+                    }
+                }
+        }
+    }
+
+    @Test
+    fun `M carry sampling decision W request is made`() {
+        // Given
+        every { mockTraceSampler.sample() } returnsBy { randomBoolean() }
+        val fakeUrl = "https://$fakeHost/track"
+        val fakeMethod = randomRedirectMethod()
+        val request = HttpRequestBuilder()
+            .apply {
+                url(fakeUrl)
+                headers["fake-header-name"] = "fake-header-value"
+                method = fakeMethod
+            }
+
+        val fakeStatusCode = HttpStatusCode.allStatusCodes
+            .filter { it.value !in 300..399 }
+            .randomElement()
+        val fakeRedirectStatusCode = HttpStatusCode.redirectStatusCodes()
+            .randomElement()
+        val fakeContextLength = nullable(randomLong())
+        everySuspend {
+            mockRequestHandler.invoke(any(), any())
+        } calls { (scope: MockRequestHandleScope, request: HttpRequestData) ->
+            if (!request.url.encodedPath.endsWith("/redirected")) {
+                scope.respond(
+                    content = "",
+                    status = fakeRedirectStatusCode,
+                    headers = Headers.build {
+                        set(HttpHeaders.Location, "$fakeUrl/redirected")
+                    }
+                )
+            } else {
+                scope.respond(
+                    content = "",
+                    status = fakeStatusCode,
+                    headers = Headers.build {
+                        if (fakeContextLength != null) {
+                            set(HttpHeaders.ContentLength, fakeContextLength.toString())
+                        }
+                    }
+                )
+            }
+        }
+
+        // When
+        runBlocking {
+            fakeClient.request(request)
+        }
+
+        // Then
+        val requests = mockEngine.requestHistory
+        assertEquals(
+            requests.first().attributes[DatadogKtorPlugin.DD_IS_SAMPLED_ATTR],
+            requests[1].attributes[DatadogKtorPlugin.DD_IS_SAMPLED_ATTR]
+        )
+    }
+
+    @Test
+    fun `M compute rule_psr W request is made`() {
+        // Given
+        val fakeSampleRate = randomFloat(from = 40f, until = 100f)
+        every { mockTraceSampler.sampleRate } returns fakeSampleRate
+        every { mockTraceSampler.sample() } returnsBy { randomFloat(0f, 100f) < fakeSampleRate }
+        val fakeUrl = "https://$fakeHost/track"
+        val fakeMethod = HttpMethod.DefaultMethods.randomElement()
+        val request = HttpRequestBuilder()
+            .apply {
+                url(fakeUrl)
+                headers["fake-header-name"] = "fake-header-value"
+                method = fakeMethod
+                setRandomBody()
+            }
+
+        val fakeStatusCode = HttpStatusCode.allStatusCodes
+            .filter { it.value !in 300..399 }
+            .randomElement()
+        val fakeContextLength = nullable(randomLong())
+        everySuspend {
+            mockRequestHandler.invoke(any(), any())
+        } calls { (scope: MockRequestHandleScope, _: HttpRequestData) ->
+            scope.respond(
+                content = "",
+                status = fakeStatusCode,
+                headers = Headers.build {
+                    if (fakeContextLength != null) {
+                        set(HttpHeaders.ContentLength, fakeContextLength.toString())
+                    }
+                }
+            )
+        }
+
+        // When
+        repeat(10) {
+            runBlocking {
+                fakeClient.request(request)
+            }
+        }
+
+        // Then
+        val capturedRulePsrValues = mutableListOf<Float>()
+        verify(VerifyMode.exactly(10)) {
+            mockRumMonitor.stopResource(
+                key = isIn(mockEngine.requestHistory.map { it.requestId }),
+                statusCode = fakeStatusCode.value,
+                size = fakeContextLength,
+                kind = RumResourceKind.NATIVE,
+                attributes = matching {
+                    val rulePsr = it[RUM_RULE_PSR] as? Float
+                    if (rulePsr != null) {
+                        capturedRulePsrValues += rulePsr
+                    }
+
+                    true
+                }
+            )
+        }
+
+        assertTrue(capturedRulePsrValues.isNotEmpty())
+        capturedRulePsrValues.forEach { assertIsWithin(it, 0f, 1f) }
+        assertTrue(capturedRulePsrValues.all { it == fakeSampleRate / 100f })
     }
 
     @Test
@@ -502,20 +666,14 @@ class DatadogKtorPluginTest {
                 url(fakeUrl)
                 headers["fake-header-name"] = "fake-header-value"
                 method = fakeMethod
-                if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
-                    setBody(
-                        listOf("body", TextContent("body", ContentType.Any))
-                            .randomElement()
-                    )
-                }
+                setRandomBody()
             }
         val fakeThrowable = ConnectTimeoutException(fakeUrl, timeout = randomLong())
+        var capturedRequestId: String? = null
         everySuspend {
-            mockRequestHandler.invoke(
-                any(),
-                any()
-            )
-        } calls { (_: MockRequestHandleScope, _: HttpRequestData) ->
+            mockRequestHandler.invoke(any(), any())
+        } calls { (_: MockRequestHandleScope, request: HttpRequestData) ->
+            capturedRequestId = request.requestId
             throw fakeThrowable
         }
 
@@ -529,24 +687,105 @@ class DatadogKtorPluginTest {
         }
 
         // Then
-        verify {
-            // TODO RUM-6456 verify request headers
+        verify(VerifyMode.exhaustiveOrder) {
             mockRumMonitor.startResource(
-                key = any(),
+                key = checkNotNull(capturedRequestId),
                 method = fakeMethod.asRumMethod(),
                 url = fakeUrl,
                 attributes = fakeRumRequestAttributes
             )
 
-            // TODO RUM-6456 verify request headers
             mockRumMonitor.stopResourceWithError(
-                key = any(),
+                key = checkNotNull(capturedRequestId),
                 statusCode = null,
                 message = "Ktor request error $fakeMethod $fakeUrl",
                 throwable = fakeThrowable,
                 attributes = fakeRumErrorAttributes
             )
         }
+
+        verifyNoMoreCalls(mockRumMonitor)
+    }
+
+    @Test
+    fun `M start + stop resource tracking with error W request failed with exception on redirect`() {
+        // Given
+        val fakeUrl = "https://$fakeHost/track"
+        val fakeMethod = randomRedirectMethod()
+        val request = HttpRequestBuilder()
+            .apply {
+                url(fakeUrl)
+                headers["fake-header-name"] = "fake-header-value"
+                method = fakeMethod
+            }
+
+        val fakeRedirectStatusCode = HttpStatusCode.redirectStatusCodes()
+            .randomElement()
+        val fakeThrowable = ConnectTimeoutException(fakeUrl, timeout = randomLong())
+        var capturedRedirectRequestId: String? = null
+        everySuspend {
+            mockRequestHandler.invoke(any(), any())
+        } calls { (scope: MockRequestHandleScope, request: HttpRequestData) ->
+            if (!request.url.encodedPath.endsWith("/redirected")) {
+                scope.respond(
+                    content = "",
+                    status = fakeRedirectStatusCode,
+                    headers = Headers.build {
+                        set(HttpHeaders.Location, "$fakeUrl/redirected")
+                    }
+                )
+            } else {
+                capturedRedirectRequestId = request.requestId
+                throw fakeThrowable
+            }
+        }
+
+        // When
+        try {
+            runBlocking {
+                fakeClient.request(request)
+            }
+        } catch (t: Throwable) {
+            assertEquals(fakeThrowable, t)
+        }
+
+        // Then
+        val firstRequestId = mockEngine.requestHistory.first().requestId
+        assertNotEquals(capturedRedirectRequestId, firstRequestId)
+
+        verify {
+            mockRumMonitor.startResource(
+                key = firstRequestId,
+                method = fakeMethod.asRumMethod(),
+                url = fakeUrl,
+                attributes = fakeRumRequestAttributes
+            )
+
+            mockRumMonitor.stopResource(
+                key = firstRequestId,
+                statusCode = fakeRedirectStatusCode.value,
+                size = null,
+                kind = RumResourceKind.NATIVE,
+                attributes = any()
+            )
+
+            mockRumMonitor.startResource(
+                key = checkNotNull(capturedRedirectRequestId),
+                method = fakeMethod.asRumMethod(),
+                url = "$fakeUrl/redirected",
+                attributes = fakeRumRequestAttributes
+            )
+
+            mockRumMonitor.stopResourceWithError(
+                key = checkNotNull(capturedRedirectRequestId),
+                statusCode = null,
+                message = "Ktor request error $fakeMethod $fakeUrl/redirected",
+                throwable = fakeThrowable,
+                attributes = fakeRumErrorAttributes
+            )
+        }
+
+        verifyNoMoreCalls(mockRumMonitor)
     }
 
     // endregion
@@ -607,6 +846,58 @@ class DatadogKtorPluginTest {
         TemporaryRedirect,
         PermanentRedirect
     )
+
+    private fun HttpRequestBuilder.setRandomBody() {
+        if (method in setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch)) {
+            setBody(
+                listOf("body", TextContent("body", ContentType.Any))
+                    .randomElement()
+            )
+        }
+    }
+
+    private val HttpRequestData.requestId: String
+        get() = attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR]
+
+    private val HttpRequestData.traceId: TraceId
+        get() = attributes[DatadogKtorPlugin.DD_TRACE_ID_ATTR]
+
+    private val HttpRequestData.spanId: SpanId
+        get() = attributes[DatadogKtorPlugin.DD_SPAN_ID_ATTR]
+
+    private val HttpRequest.requestId: String
+        get() = attributes[DatadogKtorPlugin.DD_REQUEST_ID_ATTR]
+
+    private fun expectedSpanId(spanIdDec: String, headerType: TracingHeaderType): String {
+        return when (headerType) {
+            TracingHeaderType.DATADOG -> spanIdDec
+            else -> spanIdDec.toULong().toString(HEX_RADIX).lowercase().let {
+                if (headerType == TracingHeaderType.TRACECONTEXT) {
+                    it.padStart(16, '0')
+                } else {
+                    it
+                }
+            }
+        }
+    }
+
+    private fun expectedTraceId(traceIdHex: String, headerType: TracingHeaderType): String {
+        return when (headerType) {
+            TracingHeaderType.TRACECONTEXT -> traceIdHex.padStart(32, '0')
+            else -> traceIdHex
+        }
+    }
+
+    private fun randomRedirectMethod(): HttpMethod {
+        // Only Get and Head are allowed for implicit redirect, see Ktor HttpRedirect.kt
+        return listOf(HttpMethod.Get, HttpMethod.Head)
+            .randomElement()
+    }
+
+    private fun assertIsWithin(actual: Float, from: Float, until: Float) {
+        assertTrue(actual >= from, "Expected $actual to be greater or equal $from, but it wasn't.")
+        assertTrue(actual <= until, "Expected $actual to be less or equal $until, but it wasn't.")
+    }
 
     // endregion
 }

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/test/HeadersAssert.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/test/HeadersAssert.kt
@@ -1,0 +1,208 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.ktor.test
+
+import com.datadog.kmp.ktor.HEX_RADIX
+import com.datadog.kmp.ktor.TracingHeaderType
+import io.ktor.http.Headers
+import kotlin.test.assertEquals
+
+class HeadersAssert private constructor(private val actual: Headers) {
+
+    fun hasTraceId(traceId: String, format: TracingHeaderType): HeadersAssert {
+        traceContextAssert(format)
+            .assertTraceId(actual, traceId)
+        return this
+    }
+
+    fun hasSpanId(spanId: String, format: TracingHeaderType): HeadersAssert {
+        traceContextAssert(format)
+            .assertSpanId(actual, spanId)
+        return this
+    }
+
+    fun hasSamplingDecision(samplingDecision: Int, format: TracingHeaderType): HeadersAssert {
+        traceContextAssert(format)
+            .assertSamplingDecision(actual, samplingDecision)
+        return this
+    }
+
+    private fun traceContextAssert(format: TracingHeaderType): TraceContextAssert<Headers> = when (format) {
+        TracingHeaderType.DATADOG -> DatadogTraceContextAssert
+        TracingHeaderType.TRACECONTEXT -> TraceContextContextAssert
+        TracingHeaderType.B3 -> B3TraceContextAssert
+        TracingHeaderType.B3MULTI -> B3MultiContextAssert
+    }
+
+    companion object {
+        fun assertThat(headers: Headers): HeadersAssert = HeadersAssert(headers)
+    }
+}
+
+private interface TraceContextAssert<T> {
+    fun assertTraceId(carrier: T, traceIdHex: String)
+    fun assertSpanId(carrier: T, spanIdHex: String)
+    fun assertSamplingDecision(carrier: T, samplingDecision: Int)
+}
+
+private object DatadogTraceContextAssert : TraceContextAssert<Headers> {
+
+    override fun assertTraceId(carrier: Headers, traceIdHex: String) {
+        val actualLeastSignificantTraceId = carrier["x-datadog-trace-id"]
+            ?.toULong()
+            ?.toString(HEX_RADIX)
+            ?.padStart(16, '0')
+            .orEmpty()
+        val actualMostSignificantTraceId = carrier["x-datadog-tags"]
+            ?.split(",")
+            ?.associate { it.split("=").let { it[0] to it[1] } }
+            ?.get("_dd.p.tid")
+            .orEmpty()
+        val actualTraceId = actualMostSignificantTraceId + actualLeastSignificantTraceId
+        assertEquals(
+            traceIdHex,
+            actualTraceId,
+            "Expected Datadog traceId to be $traceIdHex, but was $actualTraceId.\n${carrier.toLinesString()}"
+        )
+    }
+
+    override fun assertSpanId(carrier: Headers, spanIdHex: String) {
+        val actualSpanId = carrier["x-datadog-parent-id"]
+        assertEquals(
+            spanIdHex,
+            actualSpanId,
+            "Expected Datadog spanId to be $spanIdHex, but was $actualSpanId.\n${carrier.toLinesString()}"
+        )
+    }
+
+    override fun assertSamplingDecision(carrier: Headers, samplingDecision: Int) {
+        val actualSamplingDecision = carrier["x-datadog-sampling-priority"]
+            ?.toIntOrNull()
+        assertEquals(
+            samplingDecision,
+            actualSamplingDecision,
+            "Expected Datadog samplingDecision to be $samplingDecision," +
+                " but was $actualSamplingDecision.\n${carrier.toLinesString()}"
+        )
+    }
+}
+
+private object TraceContextContextAssert : TraceContextAssert<Headers> {
+
+    private data class TraceContext(val traceId: String, val spanId: String, val samplingDecision: Int)
+
+    override fun assertTraceId(carrier: Headers, traceIdHex: String) {
+        val actualTraceId = extractTraceContext(carrier)?.traceId
+        assertEquals(
+            traceIdHex,
+            actualTraceId,
+            "Expected TraceContext traceId to be $traceIdHex," +
+                " but was $actualTraceId.\n${carrier.toLinesString()}"
+        )
+    }
+
+    override fun assertSpanId(carrier: Headers, spanIdHex: String) {
+        val actualSpanId = extractTraceContext(carrier)?.spanId
+        assertEquals(
+            spanIdHex,
+            actualSpanId,
+            "Expected TraceContext spanId to be $spanIdHex, but was $actualSpanId.\n${carrier.toLinesString()}"
+        )
+    }
+
+    override fun assertSamplingDecision(carrier: Headers, samplingDecision: Int) {
+        val actualSamplingDecision = extractTraceContext(carrier)?.samplingDecision
+        assertEquals(
+            samplingDecision,
+            actualSamplingDecision,
+            "Expected TraceContext samplingDecision to be $samplingDecision," +
+                " but was $actualSamplingDecision.\n${carrier.toLinesString()}"
+        )
+    }
+
+    private fun extractTraceContext(headers: Headers): TraceContext? {
+        val values = headers["traceparent"]
+            ?.split("-") ?: return null
+        return TraceContext(values[1], values[2], values[3].toInt())
+    }
+}
+
+private object B3TraceContextAssert : TraceContextAssert<Headers> {
+
+    private data class TraceContext(val traceId: String, val spanId: String, val samplingDecision: Int)
+
+    override fun assertTraceId(carrier: Headers, traceIdHex: String) {
+        val actualTraceId = extractTraceContext(carrier)?.traceId
+        assertEquals(
+            traceIdHex,
+            actualTraceId,
+            "Expected B3 traceId to be $traceIdHex, but was $actualTraceId.\n${carrier.toLinesString()}"
+        )
+    }
+
+    override fun assertSpanId(carrier: Headers, spanIdHex: String) {
+        val actualSpanId = extractTraceContext(carrier)?.spanId
+        assertEquals(
+            spanIdHex,
+            actualSpanId,
+            "Expected B3 spanId to be $spanIdHex, but was $actualSpanId.\n${carrier.toLinesString()}"
+        )
+    }
+
+    override fun assertSamplingDecision(carrier: Headers, samplingDecision: Int) {
+        val actualSamplingDecision = extractTraceContext(carrier)?.samplingDecision
+        assertEquals(
+            samplingDecision,
+            actualSamplingDecision,
+            "Expected B3 samplingDecision to be $samplingDecision," +
+                " but was $actualSamplingDecision.\n${carrier.toLinesString()}"
+        )
+    }
+
+    private fun extractTraceContext(headers: Headers): TraceContext? {
+        val values = headers["b3"]
+            ?.split("-") ?: return null
+        return if (values.size > 1) {
+            TraceContext(values[0], values[1], values[2].toInt())
+        } else {
+            TraceContext("", "", values[0].toInt())
+        }
+    }
+}
+
+private object B3MultiContextAssert : TraceContextAssert<Headers> {
+
+    override fun assertTraceId(carrier: Headers, traceIdHex: String) {
+        val actualTraceId = carrier["X-B3-TraceId"]
+        assertEquals(
+            traceIdHex,
+            actualTraceId,
+            "Expected B3Multi traceId to be $traceIdHex, but was $actualTraceId.\n${carrier.toLinesString()}"
+        )
+    }
+
+    override fun assertSpanId(carrier: Headers, spanIdHex: String) {
+        val actualSpanId = carrier["X-B3-SpanId"]
+        assertEquals(
+            spanIdHex,
+            actualSpanId,
+            "Expected B3Multi spanId to be $spanIdHex, but was $actualSpanId.\n${carrier.toLinesString()}"
+        )
+    }
+
+    override fun assertSamplingDecision(carrier: Headers, samplingDecision: Int) {
+        val actualSamplingDecision = carrier["X-B3-Sampled"]?.toIntOrNull()
+        assertEquals(
+            samplingDecision,
+            actualSamplingDecision,
+            "Expected B3Multi samplingDecision to be $samplingDecision," +
+                " but was $actualSamplingDecision.\n${carrier.toLinesString()}"
+        )
+    }
+}
+
+private fun Headers.toLinesString() = "Headers\n${entries().joinToString("\n")}"

--- a/sample/androidApp/src/main/kotlin/com/datadog/kmp/android/sample/MainActivity.kt
+++ b/sample/androidApp/src/main/kotlin/com/datadog/kmp/android/sample/MainActivity.kt
@@ -56,6 +56,7 @@ import com.datadog.kmp.sample.network.startGetRequest
 import com.datadog.kmp.sample.network.startPostRequest
 import com.datadog.kmp.sample.startWebViewTracking
 import com.datadog.kmp.sample.trackAction
+import kotlin.random.Random
 import android.webkit.WebView as AndroidWebView
 
 class MainActivity : ComponentActivity() {
@@ -195,7 +196,12 @@ fun RumView() {
         ) {
             Button(onClick = {
                 trackAction("Start GET request")
-                startGetRequest("https://httpbin.org/get")
+                val url = if (Random.nextBoolean()) {
+                    "https://httpbin.org/get"
+                } else {
+                    "https://httpbin.org/redirect-to?url=get"
+                }
+                startGetRequest(url)
             }, colors = ButtonDefaults.buttonColors(containerColor = Color.Orange)) {
                 Text(text = "Trigger GET request")
             }

--- a/sample/appleApp/appleApp/ContentView.swift
+++ b/sample/appleApp/appleApp/ContentView.swift
@@ -179,8 +179,13 @@ internal struct RumView: View {
             }
 
             Button(action: {
+                let url = if (Bool.random()) {
+                    "https://httpbin.org/get"
+                } else {
+                    "https://httpbin.org/redirect-to?url=get"
+                }
                 UtilsKt.trackAction(actionName: ContentView.GET_REQUEST_LABEL)
-                NetworkUtilsKt.startGetRequest(url: "https://httpbin.org/get")
+                NetworkUtilsKt.startGetRequest(url: url)
             }) {
                 Text(ContentView.GET_REQUEST_LABEL)
                     .padding()


### PR DESCRIPTION
### What does this PR do?

This change brings support of library-initiated requests (e.g. redirects) tracking in Ktor instrumentation.

Normally requests are coming from the user, but some may be initiated by the library itself (e.g. redirects, auth requests) and  we need to track them as well. This is achieved by hooking on the `on(SendingRequest)`. 

Compared to OkHttp, Ktor doesn't have a wording `application` vs `network` interceptor, but instead it has pipelines with different stages and different hooks.

The best illustration of the behavior is coming from the [official documentation](https://ktor.io/docs/client-custom-plugins.html#call-handling):

```
The SendingRequest hook is executed for every request, even if it's not initiated by a user.

For example, if a request results in a redirect, the onRequest handler will be executed only for the original request,
while on(SendingRequest) will be executed for both original and redirected requests.

Similarly, if you used on(Send) to initiate an additional request, handlers will be ordered as follows:

--> onRequest
--> on(Send)
--> on(SendingRequest)
<-- onResponse
--> on(SendingRequest)
<-- onResponse
```

Library-initiated request will carry the sampling decision made for the user-initiated request and will have a new Request ID and Span ID as well, while keeping the same Trace ID.

NB: There is still a missing gap - errors during the body transformation. We will handle it later.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

