### PR TITLE
Add Ktor plugin initializer with default tracing header types

### DIFF
--- a/integrations/ktor/api/commonMain/apiSurface
+++ b/integrations/ktor/api/commonMain/apiSurface
@@ -1,4 +1,5 @@
 fun datadogKtorPlugin(Map<String, Set<TracingHeaderType>> = emptyMap(), Float = DEFAULT_TRACE_SAMPLE_RATE, TraceContextInjection = TraceContextInjection.All, RumResourceAttributesProvider = DefaultRumResourceAttributesProvider): io.ktor.client.plugins.api.ClientPlugin<Unit>
+fun datadogKtorPlugin(List<String> = emptyList(), Float = DEFAULT_TRACE_SAMPLE_RATE, RumResourceAttributesProvider = DefaultRumResourceAttributesProvider): io.ktor.client.plugins.api.ClientPlugin<Unit>
 const val RUM_TRACE_ID: String
 const val RUM_SPAN_ID: String
 const val RUM_RULE_PSR: String

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
@@ -22,7 +22,7 @@ internal const val DEFAULT_TRACE_SAMPLE_RATE: Float = 20f
  * @param tracedHosts the map of all the hosts to track, and the header types that you want
  * to use to handle distributed traces. For a default setup, we recommend using the DATADOG + TRACECONTEXT header types
  * for the hosts you own.
- * @param traceSampleRate the sampling rate for the tracing (between 0 and 100).
+ * @param traceSampleRate the sample rate for the tracing (between 0 and 100).
  * @param traceContextInjection the trace context injection behavior for this interceptor in the intercepted
  * requests. By default this is set to [TraceContextInjection.All] meaning that all the trace context will be
  * propagated in the intercepted requests no matter if the span created around the request is sampled or not. In case
@@ -45,4 +45,30 @@ fun datadogKtorPlugin(
         DefaultSpanIdGenerator(),
         rumResourceAttributesProvider
     ).buildClientPlugin()
+}
+
+/**
+ * Create a Datadog plugin for a Ktor [HttpClient].
+ * @param tracedHosts the list of all the hosts to track. For a default setup, DATADOG + TRACECONTEXT header types
+ * will be used.
+ * @param traceSampleRate the sample rate for the tracing (between 0 and 100).
+ * @param traceContextInjection the trace context injection behavior for this interceptor in the intercepted
+ * requests. By default this is set to [TraceContextInjection.All] meaning that all the trace context will be
+ * propagated in the intercepted requests no matter if the span created around the request is sampled or not. In case
+ * of [TraceContextInjection.Sampled] only the sampled request will propagate the trace context.
+ * @param rumResourceAttributesProvider which listens on the intercepted Ktor call chain
+ * and offers the possibility to add custom attributes to the RUM resource events.
+ */
+fun datadogKtorPlugin(
+    tracedHosts: List<String> = emptyList(),
+    traceSampleRate: Float = DEFAULT_TRACE_SAMPLE_RATE,
+    traceContextInjection: TraceContextInjection = TraceContextInjection.All,
+    rumResourceAttributesProvider: RumResourceAttributesProvider = DefaultRumResourceAttributesProvider
+): ClientPlugin<Unit> {
+    return datadogKtorPlugin(
+        tracedHosts = tracedHosts.associateWith { setOf(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT) },
+        traceSampleRate = traceSampleRate,
+        traceContextInjection = traceContextInjection,
+        rumResourceAttributesProvider = rumResourceAttributesProvider
+    )
 }

--- a/integrations/ktor3/api/commonMain/apiSurface
+++ b/integrations/ktor3/api/commonMain/apiSurface
@@ -1,4 +1,5 @@
 fun datadogKtorPlugin(Map<String, Set<TracingHeaderType>> = emptyMap(), Float = DEFAULT_TRACE_SAMPLE_RATE, TraceContextInjection = TraceContextInjection.All, RumResourceAttributesProvider = DefaultRumResourceAttributesProvider): io.ktor.client.plugins.api.ClientPlugin<Unit>
+fun datadogKtorPlugin(List<String> = emptyList(), Float = DEFAULT_TRACE_SAMPLE_RATE, TraceContextInjection = TraceContextInjection.All, RumResourceAttributesProvider = DefaultRumResourceAttributesProvider): io.ktor.client.plugins.api.ClientPlugin<Unit>
 const val RUM_TRACE_ID: String
 const val RUM_SPAN_ID: String
 const val RUM_RULE_PSR: String

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/network/NetworkClient.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/network/NetworkClient.kt
@@ -8,7 +8,6 @@ package com.datadog.kmp.sample.network
 
 import com.datadog.kmp.ktor.HttpRequestSnapshot
 import com.datadog.kmp.ktor.RumResourceAttributesProvider
-import com.datadog.kmp.ktor.TracingHeaderType
 import com.datadog.kmp.ktor.datadogKtorPlugin
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
@@ -24,14 +23,13 @@ import kotlinx.coroutines.withContext
 object NetworkClient {
 
     private const val CUSTOM_HEADER_NAME = "x-custom-header"
+    private const val HTTPBIN_HOST = "httpbin.org"
 
     private val client = HttpClient {
         followRedirects = true
         install(
             datadogKtorPlugin(
-                tracedHosts = mapOf(
-                    "httpbin.org" to setOf(TracingHeaderType.DATADOG)
-                ),
+                tracedHosts = listOf(HTTPBIN_HOST),
                 traceSampleRate = 100f,
                 rumResourceAttributesProvider = object : RumResourceAttributesProvider {
                     override fun onRequest(request: HttpRequestSnapshot) =


### PR DESCRIPTION
### What does this PR do?

The small quality of developer life improvement: add Ktor plugin initializer with default tracing header types (`Datadog` and `TraceContext`).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

