### PR TITLE
RUM-6453: Use thread-safe random

### DIFF
--- a/integrations/ktor/src/androidMain/kotlin/com/datadog/kmp/ktor/RandomExt.android.kt
+++ b/integrations/ktor/src/androidMain/kotlin/com/datadog/kmp/ktor/RandomExt.android.kt
@@ -6,4 +6,12 @@
 
 package com.datadog.kmp.ktor
 
-internal actual fun seed(): Long = System.nanoTime()
+import java.security.SecureRandom
+import kotlin.random.Random
+import kotlin.random.asKotlinRandom
+
+/**
+ * Creates implementation of [Random] backed by [SecureRandom], which is thread-safe instead of default JVM platform
+ * implementation.
+ */
+internal actual val RNG: Random = SecureRandom().asKotlinRandom()

--- a/integrations/ktor/src/appleMain/kotlin/com/datadog/kmp/ktor/RandomExt.ios.kt
+++ b/integrations/ktor/src/appleMain/kotlin/com/datadog/kmp/ktor/RandomExt.ios.kt
@@ -7,5 +7,6 @@
 package com.datadog.kmp.ktor
 
 import kotlinx.datetime.Clock
+import kotlin.random.Random
 
-internal actual fun seed(): Long = Clock.System.now().nanosecondsOfSecond.toLong()
+internal actual val RNG: Random = Random(Clock.System.now().nanosecondsOfSecond.toLong())

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/RandomExt.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/RandomExt.kt
@@ -8,7 +8,4 @@ package com.datadog.kmp.ktor
 
 import kotlin.random.Random
 
-// TODO RUM-6453 Documentation says that it is not thread-safe for JVM target, we need to handle this
-internal val RNG = Random(seed())
-
-internal expect fun seed(): Long
+internal expect val RNG: Random


### PR DESCRIPTION
### What does this PR do?

This PR switches to the usage of `SecureRandom` for Android platform, because default platform implementation is not thread-safe: if API is 34 or above, `ThreadLocalRandom` [is used](https://github.com/JetBrains/kotlin/blob/6da4e1b2134b03bcd05646ba45cf98fb5647295f/libraries/stdlib/jdk8/src/kotlin/internal/jdk8/JDK8PlatformImplementations.kt#L58), otherwise it is just `java.util.Random` [under the hood](https://github.com/JetBrains/kotlin/blob/6da4e1b2134b03bcd05646ba45cf98fb5647295f/libraries/stdlib/jvm/src/kotlin/random/PlatformRandom.kt#L50).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

