### PR TITLE
RUM-7596: Trace context injection control

### DIFF
--- a/integrations/ktor/api/commonMain/apiSurface
+++ b/integrations/ktor/api/commonMain/apiSurface
@@ -1,4 +1,4 @@
-fun datadogKtorPlugin(Map<String, Set<TracingHeaderType>> = emptyMap(), Float = DEFAULT_TRACE_SAMPLE_RATE, RumResourceAttributesProvider = DefaultRumResourceAttributesProvider): io.ktor.client.plugins.api.ClientPlugin<Unit>
+fun datadogKtorPlugin(Map<String, Set<TracingHeaderType>> = emptyMap(), Float = DEFAULT_TRACE_SAMPLE_RATE, TraceContextInjection = TraceContextInjection.All, RumResourceAttributesProvider = DefaultRumResourceAttributesProvider): io.ktor.client.plugins.api.ClientPlugin<Unit>
 const val RUM_TRACE_ID: String
 const val RUM_SPAN_ID: String
 const val RUM_RULE_PSR: String
@@ -7,6 +7,9 @@ interface com.datadog.kmp.ktor.RumResourceAttributesProvider
   fun onResponse(io.ktor.client.statement.HttpResponse): Map<String, Any?>
   fun onError(HttpRequestSnapshot, Throwable): Map<String, Any?>
 class com.datadog.kmp.ktor.HttpRequestSnapshot
+enum com.datadog.kmp.ktor.TraceContextInjection
+  - All
+  - Sampled
 enum com.datadog.kmp.ktor.TracingHeaderType
   - DATADOG
   - B3

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
@@ -22,19 +22,25 @@ internal const val DEFAULT_TRACE_SAMPLE_RATE: Float = 20f
  * @param tracedHosts the map of all the hosts to track, and the header types that you want
  * to use to handle distributed traces. For a default setup, we recommend using the DATADOG + TRACECONTEXT header types
  * for the hosts you own.
- * @param traceSamplingRate the sampling rate for the tracing (between 0 and 100)
+ * @param traceSamplingRate the sampling rate for the tracing (between 0 and 100).
+ * @param traceContextInjection the trace context injection behavior for this interceptor in the intercepted
+ * requests. By default this is set to [TraceContextInjection.All] meaning that all the trace context will be
+ * propagated in the intercepted requests no matter if the span created around the request is sampled or not. In case
+ * of [TraceContextInjection.Sampled] only the sampled request will propagate the trace context.
  * @param rumResourceAttributesProvider which listens on the intercepted Ktor call chain
  * and offers the possibility to add custom attributes to the RUM resource events.
  */
 fun datadogKtorPlugin(
     tracedHosts: Map<String, Set<TracingHeaderType>> = emptyMap(),
     traceSamplingRate: Float = DEFAULT_TRACE_SAMPLE_RATE,
+    traceContextInjection: TraceContextInjection = TraceContextInjection.All,
     rumResourceAttributesProvider: RumResourceAttributesProvider = DefaultRumResourceAttributesProvider
 ): ClientPlugin<Unit> {
     return DatadogKtorPlugin(
         RumMonitor.get(),
         tracedHosts,
         DeterministicTraceSampler(traceSamplingRate),
+        traceContextInjection,
         DefaultTraceIdGenerator(),
         DefaultSpanIdGenerator(),
         rumResourceAttributesProvider

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TraceContextInjection.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TraceContextInjection.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.ktor
+
+/**
+ * Defines whether the trace context should be injected into all requests or only sampled ones.
+ */
+enum class TraceContextInjection {
+    /**
+     * Injects trace context into all requests irrespective of the sampling decision.
+     * For example if the request trace is sampled out, the trace context will still be injected in your request
+     * headers but the sampling priority will be `0`. This will mean that the client will dictate the sampling priority
+     * on the server side and no trace will be created no matter the sampling rate at the server side.
+     */
+    All,
+
+    /**
+     * Injects trace context only into sampled requests.
+     * For example if the request trace is sampled out neither the trace context or the sampling priority will
+     * be injected into the request headers leaving the server side to make the sampling decision.
+     * This will mean that if the server side sampling rate is higher than the client side sampling rate there will
+     * be a chance that a trace will be created down the stream.
+     */
+    Sampled
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds a trace injection control: API allowing to choose if tracing headers should be added only to sampled or to all outgoing requests, allowing to pass trace context to the downstream services.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

