### PR TITLE
Pin github actions to commit hash

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup Java 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
       with:
         distribution: 'zulu'
         java-version: 17
@@ -47,7 +47,7 @@ jobs:
 
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.1.0
+      uses: gradle/actions/setup-gradle@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
       with:
         gradle-version: 8.11.1
 


### PR DESCRIPTION
### What does this PR do?

For security, third party github actions are pinned to exact commit hash instead of a floating tag version number