### PR TITLE
RUM-9486: Add setUserInfo API with mandatory user ID

### DIFF
--- a/core/api/androidMain/apiSurface
+++ b/core/api/androidMain/apiSurface
@@ -3,7 +3,8 @@ actual object com.datadog.kmp.Datadog
   actual fun initialize(Any?, com.datadog.kmp.core.configuration.Configuration, com.datadog.kmp.privacy.TrackingConsent)
   actual fun isInitialized(): Boolean
   actual fun setTrackingConsent(com.datadog.kmp.privacy.TrackingConsent)
-  actual fun setUserInfo(String?, String?, String?, Map<String, Any?>)
+  DEPRECATED actual fun setUserInfo(String?, String?, String?, Map<String, Any?>)
+  actual fun setUserInfo(String, String?, String?, Map<String, Any?>)
   actual fun addUserExtraInfo(Map<String, Any?>)
   actual fun clearAllData()
   actual fun stopInstance()

--- a/core/api/appleMain/apiSurface
+++ b/core/api/appleMain/apiSurface
@@ -3,7 +3,8 @@ actual object com.datadog.kmp.Datadog
   actual fun initialize(Any?, com.datadog.kmp.core.configuration.Configuration, com.datadog.kmp.privacy.TrackingConsent)
   actual fun isInitialized(): Boolean
   actual fun setTrackingConsent(com.datadog.kmp.privacy.TrackingConsent)
-  actual fun setUserInfo(String?, String?, String?, Map<String, Any?>)
+  DEPRECATED actual fun setUserInfo(String?, String?, String?, Map<String, Any?>)
+  actual fun setUserInfo(String, String?, String?, Map<String, Any?>)
   actual fun addUserExtraInfo(Map<String, Any?>)
   actual fun clearAllData()
   actual fun stopInstance()

--- a/core/api/commonMain/apiSurface
+++ b/core/api/commonMain/apiSurface
@@ -3,7 +3,8 @@ expect object com.datadog.kmp.Datadog
   fun initialize(Any? = null, com.datadog.kmp.core.configuration.Configuration, com.datadog.kmp.privacy.TrackingConsent)
   fun isInitialized(): Boolean
   fun setTrackingConsent(com.datadog.kmp.privacy.TrackingConsent)
-  fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
+  DEPRECATED fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
+  fun setUserInfo(String, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun addUserExtraInfo(Map<String, Any?>)
   fun clearAllData()
   fun stopInstance()

--- a/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -90,6 +90,10 @@ actual object Datadog {
      * @param extraInfo additional information. An extra information can be
      * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
      */
+    @Deprecated(
+        "Use setUserInfo call with mandatory User ID instead."
+    )
+    @JvmName("setUserInfoDeprecated")
     actual fun setUserInfo(
         id: String?,
         name: String?,
@@ -97,6 +101,24 @@ actual object Datadog {
         extraInfo: Map<String, Any?>
     ) {
         @Suppress("DEPRECATION")
+        DatadogAndroid.setUserInfo(id, name, email, extraInfo)
+    }
+
+    /**
+     * Sets the user information.
+     *
+     * @param id (mandatory) a unique user identifier (relevant to your business domain)
+     * @param name (nullable) the user name or alias
+     * @param email (nullable) the user email
+     * @param extraInfo additional information. An extra information can be
+     * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
+     */
+    actual fun setUserInfo(
+        id: String,
+        name: String?,
+        email: String?,
+        extraInfo: Map<String, Any?>
+    ) {
         DatadogAndroid.setUserInfo(id, name, email, extraInfo)
     }
 

--- a/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -104,6 +104,9 @@ actual object Datadog {
      * @param extraInfo additional information. An extra information can be
      * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
      */
+    @Deprecated(
+        "Use setUserInfo call with mandatory User ID instead."
+    )
     actual fun setUserInfo(
         id: String?,
         name: String?,
@@ -111,6 +114,29 @@ actual object Datadog {
         extraInfo: Map<String, Any?>
     ) {
         DatadogIOS.setUserInfoWithId(
+            id,
+            name,
+            email,
+            extraInfo.eraseKeyType()
+        )
+    }
+
+    /**
+     * Sets the user information.
+     *
+     * @param id (mandatory) a unique user identifier (relevant to your business domain)
+     * @param name (nullable) the user name or alias
+     * @param email (nullable) the user email
+     * @param extraInfo additional information. An extra information can be
+     * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
+     */
+    actual fun setUserInfo(
+        id: String,
+        name: String?,
+        email: String?,
+        extraInfo: Map<String, Any?>
+    ) {
+        DatadogIOS.setUserInfoWithUserId(
             id,
             name,
             email,

--- a/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -66,8 +66,27 @@ expect object Datadog {
      * @param extraInfo additional information. An extra information can be
      * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
      */
+    @Deprecated(
+        "Use setUserInfo call with mandatory User ID instead."
+    )
     fun setUserInfo(
         id: String? = null,
+        name: String? = null,
+        email: String? = null,
+        extraInfo: Map<String, Any?> = emptyMap()
+    )
+
+    /**
+     * Sets the user information.
+     *
+     * @param id (mandatory) a unique user identifier (relevant to your business domain)
+     * @param name (nullable) the user name or alias
+     * @param email (nullable) the user email
+     * @param extraInfo additional information. An extra information can be
+     * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
+     */
+    fun setUserInfo(
+        id: String,
         name: String? = null,
         email: String? = null,
         extraInfo: Map<String, Any?> = emptyMap()

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
@@ -86,6 +86,7 @@ fun initDatadog(context: Any? = null) {
     initSessionReplay()
 
     Datadog.setUserInfo(
+        id = "123456789",
         name = "Random User",
         email = "user@example.com",
         extraInfo = mapOf(


### PR DESCRIPTION
### What does this PR do?

This PR brings a new API: `setUserInfo` with a mandatory user ID, to catch up with a similar change done before in the iOS and Android SDKs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

