### PR TITLE
RUM-10482: Add support for account info APIs

### DIFF
--- a/core/api/androidMain/apiSurface
+++ b/core/api/androidMain/apiSurface
@@ -6,5 +6,8 @@ actual object com.datadog.kmp.Datadog
   DEPRECATED actual fun setUserInfo(String?, String?, String?, Map<String, Any?>)
   actual fun setUserInfo(String, String?, String?, Map<String, Any?>)
   actual fun addUserExtraInfo(Map<String, Any?>)
+  actual fun setAccountInfo(String, String?, Map<String, Any?>)
+  actual fun addAccountExtraInfo(Map<String, Any?>)
+  actual fun clearAccountInfo()
   actual fun clearAllData()
   actual fun stopInstance()

--- a/core/api/appleMain/apiSurface
+++ b/core/api/appleMain/apiSurface
@@ -6,6 +6,9 @@ actual object com.datadog.kmp.Datadog
   DEPRECATED actual fun setUserInfo(String?, String?, String?, Map<String, Any?>)
   actual fun setUserInfo(String, String?, String?, Map<String, Any?>)
   actual fun addUserExtraInfo(Map<String, Any?>)
+  actual fun setAccountInfo(String, String?, Map<String, Any?>)
+  actual fun addAccountExtraInfo(Map<String, Any?>)
+  actual fun clearAccountInfo()
   actual fun clearAllData()
   actual fun stopInstance()
 fun Configuration.Builder.enableBackgroundTasks(Boolean): Configuration.Builder

--- a/core/api/commonMain/apiSurface
+++ b/core/api/commonMain/apiSurface
@@ -6,6 +6,9 @@ expect object com.datadog.kmp.Datadog
   DEPRECATED fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun setUserInfo(String, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun addUserExtraInfo(Map<String, Any?>)
+  fun setAccountInfo(String, String? = null, Map<String, Any?> = emptyMap())
+  fun addAccountExtraInfo(Map<String, Any?>)
+  fun clearAccountInfo()
   fun clearAllData()
   fun stopInstance()
 enum com.datadog.kmp.DatadogSite

--- a/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -136,6 +136,59 @@ actual object Datadog {
     }
 
     /**
+     * Sets the account information that the user is currently logged into.
+     *
+     * This API should be used to assign an identifier for the user's account which represents a
+     * contextual identity within the app, typically tied to business or tenant logic. The
+     * information set here will be added to logs, traces and RUM events.
+     *
+     * This value should be set when user logs in with his account, and cleared by calling
+     * [clearAccountInfo] when he logs out.
+     *
+     * @param id Account ID.
+     * @param name representing the account, if exists.
+     * @param extraInfo Account custom attributes, if exists.
+     */
+    actual fun setAccountInfo(
+        id: String,
+        name: String?,
+        extraInfo: Map<String, Any?>
+    ) {
+        DatadogAndroid.setAccountInfo(id, name, extraInfo)
+    }
+
+    /**
+     * Add custom attributes to the current account information.
+     *
+     * This extra info will be added to already existing extra info that is added
+     * to Logs, Traces and RUM events automatically.
+     *
+     * @param extraInfo Account additional custom attributes.
+     */
+    actual fun addAccountExtraInfo(extraInfo: Map<String, Any?>) {
+        DatadogAndroid.addAccountExtraInfo(extraInfo)
+    }
+
+    /**
+     * Clear the current account information.
+     *
+     * Account information will be set to null.
+     * Following Logs, Traces, RUM Events will not include the account information anymore.
+     *
+     * Any active RUM Session, active RUM View at the time of call will have their `account` attribute cleared.
+     *
+     * If you want to retain the current `account` on the active RUM session,
+     * you need to stop the session first by using `RumMonitor.get().stopSession()`.
+     *
+     * If you want to retain the current `account` on the active RUM views,
+     * you need to stop the view first by using `RumMonitor.get().stopView()`.
+     *
+     */
+    actual fun clearAccountInfo() {
+        DatadogAndroid.clearAccountInfo()
+    }
+
+    /**
      * Clears all unsent data in all registered features.
      */
     actual fun clearAllData() {

--- a/core/src/androidUnitTest/kotlin/com/datadog/kmp/DatadogTest.kt
+++ b/core/src/androidUnitTest/kotlin/com/datadog/kmp/DatadogTest.kt
@@ -162,6 +162,57 @@ internal class DatadogTest {
     }
 
     @Test
+    fun `M call setAccountInfo on implementation instance W setAccountInfo`(
+        @StringForgery id: String,
+        @StringForgery name: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+        ) extraInfo: Map<String, String>
+    ) {
+        // When
+        Datadog.setAccountInfo(id, name, extraInfo)
+
+        // Then
+        datadogAndroidStatic.verify {
+            DatadogAndroid.setAccountInfo(
+                id = id,
+                name = name,
+                extraInfo = extraInfo
+            )
+        }
+    }
+
+    @Test
+    fun `M call addAccountExtraInfo on implementation instance W addAccountExtraInfo`(
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+        ) extraInfo: Map<String, String>
+    ) {
+        // When
+        Datadog.addAccountExtraInfo(extraInfo)
+
+        // Then
+        datadogAndroidStatic.verify {
+            DatadogAndroid.addAccountExtraInfo(
+                extraInfo = extraInfo
+            )
+        }
+    }
+
+    @Test
+    fun `M call clearAccountInfo on implementation instance W clearAccountInfo`() {
+        // When
+        Datadog.clearAccountInfo()
+
+        // Then
+        datadogAndroidStatic.verify {
+            DatadogAndroid.clearAccountInfo()
+        }
+    }
+
+    @Test
     fun `M call setTrackingConsent on implementation instance W setTrackingConsent`(
         @Forgery trackingConsent: TrackingConsent
     ) {

--- a/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -158,6 +158,59 @@ actual object Datadog {
     }
 
     /**
+     * Sets the account information that the user is currently logged into.
+     *
+     * This API should be used to assign an identifier for the user's account which represents a
+     * contextual identity within the app, typically tied to business or tenant logic. The
+     * information set here will be added to logs, traces and RUM events.
+     *
+     * This value should be set when user logs in with his account, and cleared by calling
+     * [clearAccountInfo] when he logs out.
+     *
+     * @param id Account ID.
+     * @param name representing the account, if exists.
+     * @param extraInfo Account's custom attributes, if exists.
+     */
+    actual fun setAccountInfo(
+        id: String,
+        name: String?,
+        extraInfo: Map<String, Any?>
+    ) {
+        DatadogIOS.setAccountInfoWithAccountId(id, name, extraInfo.eraseKeyType())
+    }
+
+    /**
+     * Add custom attributes to the current account information.
+     *
+     * This extra info will be added to already existing extra info that is added
+     * to Logs, Traces and RUM events automatically.
+     *
+     * @param extraInfo Account's additional custom attributes.
+     */
+    actual fun addAccountExtraInfo(extraInfo: Map<String, Any?>) {
+        DatadogIOS.addAccountExtraInfo(extraInfo.eraseKeyType())
+    }
+
+    /**
+     * Clear the current account information.
+     *
+     * Account information will set to null
+     * Following Logs, Traces, RUM Events will not include the account information anymore.
+     *
+     * Any active RUM Session, active RUM View at the time of call will have their `account` attribute cleared
+     *
+     * If you want to retain the current `account` on the active RUM session,
+     * you need to stop the session first by using `RumMonitor.get().stopSession()`
+     *
+     * If you want to retain the current `account` on the active RUM views,
+     * you need to stop the view first by using `RumMonitor.get().stopView()`.
+     *
+     */
+    actual fun clearAccountInfo() {
+        DatadogIOS.clearAccountInfo()
+    }
+
+    /**
      * Clears all unsent data in all registered features.
      */
     actual fun clearAllData() {

--- a/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -104,6 +104,53 @@ expect object Datadog {
     fun addUserExtraInfo(extraInfo: Map<String, Any?>)
 
     /**
+     * Sets the account information that the user is currently logged into.
+     *
+     * This API should be used to assign an identifier for the user's account which represents a
+     * contextual identity within the app, typically tied to business or tenant logic. The
+     * information set here will be added to logs, traces and RUM events.
+     *
+     * This value should be set when user logs in with his account, and cleared by calling
+     * [clearAccountInfo] when he logs out.
+     *
+     * @param id Account ID.
+     * @param name representing the account, if exists.
+     * @param extraInfo Account custom attributes, if exists.
+     */
+    fun setAccountInfo(
+        id: String,
+        name: String? = null,
+        extraInfo: Map<String, Any?> = emptyMap()
+    )
+
+    /**
+     * Add custom attributes to the current account information.
+     *
+     * This extra info will be added to already existing extra info that is added
+     * to Logs, Traces and RUM events automatically.
+     *
+     * @param extraInfo Account additional custom attributes.
+     */
+    fun addAccountExtraInfo(extraInfo: Map<String, Any?>)
+
+    /**
+     * Clear the current account information.
+     *
+     * Account information will be set to null.
+     * Following Logs, Traces, RUM Events will not include the account information anymore.
+     *
+     * Any active RUM Session, active RUM View at the time of call will have their `account` attribute cleared.
+     *
+     * If you want to retain the current `account` on the active RUM session,
+     * you need to stop the session first by using `RumMonitor.get().stopSession()`.
+     *
+     * If you want to retain the current `account` on the active RUM views,
+     * you need to stop the view first by using `RumMonitor.get().stopView()`.
+     *
+     */
+    fun clearAccountInfo()
+
+    /**
      * Clears all unsent data in all registered features.
      */
     fun clearAllData()

--- a/features/logs/api/commonMain/apiSurface
+++ b/features/logs/api/commonMain/apiSurface
@@ -38,13 +38,15 @@ class com.datadog.kmp.log.configuration.LogsConfiguration
     fun setEventMapper(com.datadog.kmp.event.EventMapper<com.datadog.kmp.log.model.LogEvent>): Builder
     fun build(): LogsConfiguration
 data class com.datadog.kmp.log.model.LogEvent
-  constructor(Status, kotlin.String, kotlin.String, kotlin.String, Logger, Dd, Usr? = null, Error? = null, kotlin.String? = null, kotlin.String, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+  constructor(Status, kotlin.String, kotlin.String, kotlin.String, Logger, Dd, Usr? = null, Account? = null, Error? = null, kotlin.String? = null, kotlin.String, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
   data class Logger
     constructor(kotlin.String, kotlin.String)
   data class Dd
     constructor(Device)
   data class Usr
     constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+  data class Account
+    constructor(kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
   data class Error
     constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
   data class Device

--- a/features/logs/src/androidUnitTest/kotlin/com/datadog/kmp/log/utils/forge/LogEventForgeryFactory.kt
+++ b/features/logs/src/androidUnitTest/kotlin/com/datadog/kmp/log/utils/forge/LogEventForgeryFactory.kt
@@ -81,6 +81,13 @@ internal class LogEventForgeryFactory : ForgeryFactory<LogEvent> {
                     additionalProperties = forge.exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                LogEvent.Account(
+                    id = anHexadecimalString(),
+                    name = forge.aNullable { forge.aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = forge.exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
+                )
+            },
             network = forge.aNullable {
                 LogEvent.Network(
                     client = LogEvent.Client(

--- a/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/configuration/internal/IOSLogsConfigurationBuilder.kt
+++ b/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/configuration/internal/IOSLogsConfigurationBuilder.kt
@@ -40,6 +40,8 @@ internal class IOSLogsConfigurationBuilder : PlatformLogsConfigurationBuilder<DD
                 logEvent.userInfo().setExtraInfo(eraseKeyType(it))
             }
 
+            // TODO RUM-10485 LogEvent.account is missing in iOS SDK ObjC API
+
             logEvent
         }
     }

--- a/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/model/internal/LogEventMappingExt.kt
+++ b/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/model/internal/LogEventMappingExt.kt
@@ -34,6 +34,7 @@ internal fun DDLogEvent.toCommonModel(): LogEvent = LogEvent(
     ),
     dd = dd().toCommonModel(),
     usr = userInfo().toCommonModel(),
+    // TODO RUM-10485 LogEvent.account is missing in iOS SDK ObjC API
     // TODO RUM-6098 The way network/carrier information is passed varies a lot between Android and iOS, removing it
     //  from the model for now
     error = error()?.toCommonModel(),

--- a/features/logs/src/commonMain/json/log/log-schema.json
+++ b/features/logs/src/commonMain/json/log/log-schema.json
@@ -105,6 +105,26 @@
       },
       "readOnly": true
     },
+    "account": {
+      "type": "object",
+      "description": "Account properties",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier of the account",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the account",
+          "readOnly": true
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      },
+      "readOnly": true
+    },
     "error": {
       "type": "object",
       "description": "The additional error information in case this log is marked as an error",

--- a/features/rum/api/commonMain/apiSurface
+++ b/features/rum/api/commonMain/apiSurface
@@ -83,7 +83,7 @@ enum com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
 fun interface com.datadog.kmp.rum.event.ViewEventMapper : com.datadog.kmp.event.EventMapper<com.datadog.kmp.rum.model.ViewEvent>
   override fun map(com.datadog.kmp.rum.model.ViewEvent): com.datadog.kmp.rum.model.ViewEvent
 data class com.datadog.kmp.rum.model.ActionEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ActionEventSession, ActionEventSource? = null, ActionEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, ActionEventAction)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ActionEventSession, ActionEventSource? = null, ActionEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, ActionEventAction)
   val type: kotlin.String
   data class Application
     constructor(kotlin.String)
@@ -93,6 +93,8 @@ data class com.datadog.kmp.rum.model.ActionEvent
     constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null, kotlin.Boolean? = null)
   data class Usr
     constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+  data class Account
+    constructor(kotlin.String, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
   data class Connectivity
     constructor(Status, EffectiveType? = null, Cellular? = null)
   data class Display
@@ -198,7 +200,7 @@ data class com.datadog.kmp.rum.model.ActionEvent
     - FROM_NON_INTERACTIVE_SESSION
     - EXPLICIT_STOP
 data class com.datadog.kmp.rum.model.ErrorEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, ErrorEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, Error, Context? = null)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, ErrorEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, Error, Context? = null)
   val type: kotlin.String
   data class Application
     constructor(kotlin.String)
@@ -208,6 +210,8 @@ data class com.datadog.kmp.rum.model.ErrorEvent
     constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null, kotlin.Boolean? = null)
   data class Usr
     constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+  data class Account
+    constructor(kotlin.String, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
   data class Connectivity
     constructor(Status, EffectiveType? = null, Cellular? = null)
   data class Display
@@ -359,7 +363,7 @@ data class com.datadog.kmp.rum.model.ErrorEvent
     - UTILITY
     - VIDEO
 data class com.datadog.kmp.rum.model.LongTaskEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, LongTaskEventSession, LongTaskEventSource? = null, LongTaskEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, LongTask)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, LongTaskEventSession, LongTaskEventSource? = null, LongTaskEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, LongTask)
   val type: kotlin.String
   data class Application
     constructor(kotlin.String)
@@ -369,6 +373,8 @@ data class com.datadog.kmp.rum.model.LongTaskEvent
     constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null)
   data class Usr
     constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+  data class Account
+    constructor(kotlin.String, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
   data class Connectivity
     constructor(Status, EffectiveType? = null, Cellular? = null)
   data class Display
@@ -451,7 +457,7 @@ data class com.datadog.kmp.rum.model.LongTaskEvent
     - FROM_NON_INTERACTIVE_SESSION
     - EXPLICIT_STOP
 data class com.datadog.kmp.rum.model.ResourceEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ResourceEventSession, ResourceEventSource? = null, ResourceEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, Resource)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ResourceEventSession, ResourceEventSource? = null, ResourceEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, Resource)
   val type: kotlin.String
   data class Application
     constructor(kotlin.String)
@@ -461,6 +467,8 @@ data class com.datadog.kmp.rum.model.ResourceEvent
     constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null)
   data class Usr
     constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+  data class Account
+    constructor(kotlin.String, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
   data class Connectivity
     constructor(Status, EffectiveType? = null, Cellular? = null)
   data class Display
@@ -604,7 +612,7 @@ data class com.datadog.kmp.rum.model.ResourceEvent
     - MUTATION
     - SUBSCRIPTION
 data class com.datadog.kmp.rum.model.ViewEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ViewEventSession, ViewEventSource? = null, ViewEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, Context? = null, Privacy? = null)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ViewEventSession, ViewEventSource? = null, ViewEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, Context? = null, Privacy? = null)
   val type: kotlin.String
   data class Application
     constructor(kotlin.String)
@@ -614,6 +622,8 @@ data class com.datadog.kmp.rum.model.ViewEvent
     constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null, kotlin.Long? = null, LoadingType? = null, kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, CustomTimings? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, Action, Error, Crash? = null, LongTask? = null, FrozenFrame? = null, Resource, Frustration? = null, kotlin.collections.List<InForegroundPeriod>? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, FlutterBuildTime? = null, FlutterBuildTime? = null, FlutterBuildTime? = null)
   data class Usr
     constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+  data class Account
+    constructor(kotlin.String, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
   data class Connectivity
     constructor(Status, EffectiveType? = null, Cellular? = null)
   data class Display

--- a/features/rum/build.gradle.kts
+++ b/features/rum/build.gradle.kts
@@ -190,6 +190,7 @@ jsonSchemaGenerator {
             typeNameRemapping = mapOf(
                 "Connectivity" to "RUMConnectivity",
                 "USR" to "RUMUser",
+                "Account" to "RUMAccount",
                 "Method" to "RUMMethod",
                 "Context" to "RUMEventAttributes",
                 "CiTest" to "RUMCITest",

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ActionEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ActionEventForgeryFactory.kt
@@ -71,6 +71,13 @@ internal class ActionEventForgeryFactory :
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                ActionEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             application = ActionEvent.Application(forge.getForgery<UUID>().toString()),
             service = forge.aNullable { anAlphabeticalString() },
             session = ActionEvent.ActionEventSession(

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ErrorEventForgeryFactory.kt
@@ -91,6 +91,13 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                ErrorEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             action = forge.aNullable { ErrorEvent.Action(aList { getForgery<UUID>().toString() }) },
             application = ErrorEvent.Application(forge.getForgery<UUID>().toString()),
             service = forge.aNullable { anAlphabeticalString() },

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/LongTaskEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/LongTaskEventForgeryFactory.kt
@@ -56,6 +56,13 @@ internal class LongTaskEventForgeryFactory :
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                LongTaskEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             action = forge.aNullable {
                 LongTaskEvent.Action(aList { getForgery<UUID>().toString() })
             },

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ResourceEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ResourceEventForgeryFactory.kt
@@ -131,6 +131,13 @@ internal class ResourceEventForgeryFactory :
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                ResourceEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             action = forge.aNullable {
                 ResourceEvent.Action(aList { getForgery<UUID>().toString() })
             },

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -91,6 +91,13 @@ internal class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                ViewEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             application = ViewEvent.Application(forge.getForgery<UUID>().toString()),
             service = forge.aNullable { anAlphabeticalString() },
             session = ViewEvent.ViewEventSession(

--- a/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/configuration/internal/AppleRumConfigurationBuilder.kt
+++ b/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/configuration/internal/AppleRumConfigurationBuilder.kt
@@ -89,6 +89,10 @@ internal abstract class AppleRumConfigurationBuilder : PlatformRumConfigurationB
                 view.usr()?.setUsrInfo(eraseKeyType(it))
             }
 
+            mapped.account?.additionalProperties?.let {
+                view.account()?.setAccountInfo(eraseKeyType(it))
+            }
+
             mapped.context?.additionalProperties?.let {
                 view.context()?.setContextInfo(eraseKeyType(it))
             }
@@ -115,6 +119,10 @@ internal abstract class AppleRumConfigurationBuilder : PlatformRumConfigurationB
                 resource.usr()?.setUsrInfo(eraseKeyType(it))
             }
 
+            mapped.account?.additionalProperties?.let {
+                resource.account()?.setAccountInfo(eraseKeyType(it))
+            }
+
             mapped.context?.additionalProperties?.let {
                 resource.context()?.setContextInfo(eraseKeyType(it))
             }
@@ -138,6 +146,10 @@ internal abstract class AppleRumConfigurationBuilder : PlatformRumConfigurationB
 
             mapped.usr?.additionalProperties?.let {
                 action.usr()?.setUsrInfo(eraseKeyType(it))
+            }
+
+            mapped.account?.additionalProperties?.let {
+                action.account()?.setAccountInfo(eraseKeyType(it))
             }
 
             mapped.context?.additionalProperties?.let {
@@ -190,6 +202,10 @@ internal abstract class AppleRumConfigurationBuilder : PlatformRumConfigurationB
                 error.usr()?.setUsrInfo(eraseKeyType(it))
             }
 
+            mapped.account?.additionalProperties?.let {
+                error.account()?.setAccountInfo(eraseKeyType(it))
+            }
+
             mapped.context?.additionalProperties?.let {
                 error.context()?.setContextInfo(eraseKeyType(it))
             }
@@ -206,6 +222,18 @@ internal abstract class AppleRumConfigurationBuilder : PlatformRumConfigurationB
             longTask.view().setReferrer(mapped.view.referrer)
             longTask.view().setUrl(mapped.view.url)
             longTask.view().setName(mapped.view.name)
+
+            mapped.usr?.additionalProperties?.let {
+                longTask.usr()?.setUsrInfo(eraseKeyType(it))
+            }
+
+            mapped.account?.additionalProperties?.let {
+                longTask.account()?.setAccountInfo(eraseKeyType(it))
+            }
+
+            mapped.context?.additionalProperties?.let {
+                longTask.context()?.setContextInfo(eraseKeyType(it))
+            }
 
             longTask
         }

--- a/features/rum/src/commonMain/json/rum/_common-schema.json
+++ b/features/rum/src/commonMain/json/rum/_common-schema.json
@@ -127,6 +127,25 @@
       },
       "readOnly": true
     },
+    "account": {
+      "type": "object",
+      "description": "Account properties",
+      "additionalProperties": true,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier of the account",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the account",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
     "connectivity": {
       "type": "object",
       "description": "Device connectivity properties",

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
@@ -36,7 +36,7 @@ const val WEB_VIEW_TRACKING_LOAD_URL = "https://datadoghq.dev/browser-sdk-test-p
     "&application_id=${LibraryConfig.DD_APPLICATION_ID}" +
     "&site=datadoghq.com"
 
-@Suppress("MagicNumber", "LongMethod")
+@Suppress("MagicNumber", "LongMethod", "StringLiteralDuplication")
 fun initDatadog(context: Any? = null) {
     Datadog.verbosity = SdkLogVerbosity.DEBUG
 
@@ -94,8 +94,18 @@ fun initDatadog(context: Any? = null) {
             "age" to 42,
             "location" to "universe",
             "boolean-attribute" to true,
-            "null-attribute" to null,
-            "boolean-attribute" to true
+            "null-attribute" to null
+        )
+    )
+
+    Datadog.setAccountInfo(
+        id = "987654321",
+        name = "Random Account",
+        extraInfo = mapOf(
+            "age" to 42,
+            "location" to "universe",
+            "boolean-attribute" to true,
+            "null-attribute" to null
         )
     )
 }


### PR DESCRIPTION
### What does this PR do?

This PR brings support for the `account`-related APIs already implemented in iOS and Android SDKs.

There is a tiny gap in the iOS SDK ObjC API for Logs: there is no `accountInfo` property for the `LogEvent`, but this is not a blocker.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

