### PR TITLE
RUM-11437: Add `Datadog.clearUserInfo` API

### DIFF
--- a/core/api/androidMain/apiSurface
+++ b/core/api/androidMain/apiSurface
@@ -6,6 +6,7 @@ actual object com.datadog.kmp.Datadog
   DEPRECATED actual fun setUserInfo(String?, String?, String?, Map<String, Any?>)
   actual fun setUserInfo(String, String?, String?, Map<String, Any?>)
   actual fun addUserExtraInfo(Map<String, Any?>)
+  actual fun clearUserInfo()
   actual fun setAccountInfo(String, String?, Map<String, Any?>)
   actual fun addAccountExtraInfo(Map<String, Any?>)
   actual fun clearAccountInfo()

--- a/core/api/appleMain/apiSurface
+++ b/core/api/appleMain/apiSurface
@@ -6,6 +6,7 @@ actual object com.datadog.kmp.Datadog
   DEPRECATED actual fun setUserInfo(String?, String?, String?, Map<String, Any?>)
   actual fun setUserInfo(String, String?, String?, Map<String, Any?>)
   actual fun addUserExtraInfo(Map<String, Any?>)
+  actual fun clearUserInfo()
   actual fun setAccountInfo(String, String?, Map<String, Any?>)
   actual fun addAccountExtraInfo(Map<String, Any?>)
   actual fun clearAccountInfo()

--- a/core/api/commonMain/apiSurface
+++ b/core/api/commonMain/apiSurface
@@ -6,6 +6,7 @@ expect object com.datadog.kmp.Datadog
   DEPRECATED fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun setUserInfo(String, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun addUserExtraInfo(Map<String, Any?>)
+  fun clearUserInfo()
   fun setAccountInfo(String, String? = null, Map<String, Any?> = emptyMap())
   fun addAccountExtraInfo(Map<String, Any?>)
   fun clearAccountInfo()

--- a/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -26,6 +26,7 @@ import com.datadog.android.privacy.TrackingConsent as TrackingConsentAndroid
 /**
  * This class initializes the Datadog SDK, and sets up communication with the server.
  */
+@Suppress("TooManyFunctions")
 actual object Datadog {
 
     /**
@@ -133,6 +134,24 @@ actual object Datadog {
      */
     actual fun addUserExtraInfo(extraInfo: Map<String, Any?>) {
         DatadogAndroid.addUserProperties(extraInfo)
+    }
+
+    /**
+     * Clear the current user information.
+     *
+     * User information will be set to null.
+     * Following Logs, Traces, RUM Events will not include the user information anymore.
+     *
+     * Any active RUM Session, active RUM View at the time of call will have their `usr` attribute cleared.
+     *
+     * If you want to retain the current `usr` on the active RUM session,
+     * you need to stop the session first by using `RumMonitor.get().stopSession()`
+     *
+     * If you want to retain the current `usr` on the active RUM views,
+     * you need to stop the view first by using `RumMonitor.get().stopView()`
+     */
+    actual fun clearUserInfo() {
+        DatadogAndroid.clearUserInfo()
     }
 
     /**

--- a/core/src/androidUnitTest/kotlin/com/datadog/kmp/DatadogTest.kt
+++ b/core/src/androidUnitTest/kotlin/com/datadog/kmp/DatadogTest.kt
@@ -162,6 +162,17 @@ internal class DatadogTest {
     }
 
     @Test
+    fun `M call clearUserInfo on implementation instance W clearUserInfo`() {
+        // When
+        Datadog.clearUserInfo()
+
+        // Then
+        datadogAndroidStatic.verify {
+            DatadogAndroid.clearUserInfo()
+        }
+    }
+
+    @Test
     fun `M call setAccountInfo on implementation instance W setAccountInfo`(
         @StringForgery id: String,
         @StringForgery name: String,

--- a/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -38,6 +38,7 @@ import cocoapods.DatadogObjc.DDDatadog as DatadogIOS
 /**
  * This class initializes the Datadog SDK, and sets up communication with the server.
  */
+@Suppress("TooManyFunctions")
 actual object Datadog {
 
     /**
@@ -155,6 +156,24 @@ actual object Datadog {
      */
     actual fun addUserExtraInfo(extraInfo: Map<String, Any?>) {
         DatadogIOS.addUserExtraInfo(extraInfo.eraseKeyType())
+    }
+
+    /**
+     * Clear the current user information.
+     *
+     * User information will be set to null.
+     * Following Logs, Traces, RUM Events will not include the user information anymore.
+     *
+     * Any active RUM Session, active RUM View at the time of call will have their `usr` attribute cleared.
+     *
+     * If you want to retain the current `usr` on the active RUM session,
+     * you need to stop the session first by using `RumMonitor.get().stopSession()`
+     *
+     * If you want to retain the current `usr` on the active RUM views,
+     * you need to stop the view first by using `RumMonitor.get().stopView()`
+     */
+    actual fun clearUserInfo() {
+        DatadogIOS.clearUserInfo()
     }
 
     /**

--- a/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -12,6 +12,7 @@ import com.datadog.kmp.privacy.TrackingConsent
 /**
  * This class initializes the Datadog SDK, and sets up communication with the server.
  */
+@Suppress("TooManyFunctions")
 expect object Datadog {
 
     /**
@@ -102,6 +103,22 @@ expect object Datadog {
      * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
      */
     fun addUserExtraInfo(extraInfo: Map<String, Any?>)
+
+    /**
+     * Clear the current user information.
+     *
+     * User information will be set to null.
+     * Following Logs, Traces, RUM Events will not include the user information anymore.
+     *
+     * Any active RUM Session, active RUM View at the time of call will have their `usr` attribute cleared.
+     *
+     * If you want to retain the current `usr` on the active RUM session,
+     * you need to stop the session first by using `RumMonitor.get().stopSession()`
+     *
+     * If you want to retain the current `usr` on the active RUM views,
+     * you need to stop the view first by using `RumMonitor.get().stopView()`
+     */
+    fun clearUserInfo()
 
     /**
      * Sets the account information that the user is currently logged into.


### PR DESCRIPTION
### What does this PR do?

This PR adds `Datadog.clearUserInfo` API following iOS and Android SDKs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

