### PR TITLE
RUM-9966: Add RUM Session ID to the trace context propagation headers

### DIFF
--- a/features/rum/api/commonMain/apiSurface
+++ b/features/rum/api/commonMain/apiSurface
@@ -76,6 +76,10 @@ class com.datadog.kmp.rum.configuration.RumConfiguration
     fun build(): RumConfiguration
 fun interface com.datadog.kmp.rum.configuration.RumSessionListener
   fun onSessionStarted(String, Boolean)
+interface com.datadog.kmp.rum.configuration.RumSessionProvider
+  val sessionId: String?
+  companion object 
+    fun get(): RumSessionProvider
 enum com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
   - FREQUENT
   - AVERAGE

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
@@ -7,12 +7,14 @@
 package com.datadog.kmp.rum.configuration
 
 import com.datadog.kmp.event.EventMapper
+import com.datadog.kmp.rum.configuration.internal.CombinedRumSessionListener
 import com.datadog.kmp.rum.configuration.internal.PlatformRumConfigurationBuilder
 import com.datadog.kmp.rum.event.ViewEventMapper
 import com.datadog.kmp.rum.model.ActionEvent
 import com.datadog.kmp.rum.model.ErrorEvent
 import com.datadog.kmp.rum.model.LongTaskEvent
 import com.datadog.kmp.rum.model.ResourceEvent
+import com.datadog.kmp.rum.model.ViewEvent
 
 /**
  * Describes configuration to be used for the RUM feature.
@@ -26,6 +28,7 @@ class RumConfiguration internal constructor(internal val nativeConfiguration: An
     class Builder {
 
         internal val platformBuilder: PlatformRumConfigurationBuilder<*>
+        private var userSessionListener: RumSessionListener? = null
 
         /**
          * Creates a new instance of [Builder].
@@ -116,7 +119,7 @@ class RumConfiguration internal constructor(internal val nativeConfiguration: An
          * @param sessionListener the listener to notify whenever a new Session starts.
          */
         fun setSessionListener(sessionListener: RumSessionListener): Builder {
-            platformBuilder.setSessionListener(sessionListener)
+            this.userSessionListener = sessionListener
             return this
         }
 
@@ -191,6 +194,11 @@ class RumConfiguration internal constructor(internal val nativeConfiguration: An
          * Builds a [RumConfiguration] based on the current state of this Builder.
          */
         fun build(): RumConfiguration {
+            val internalSessionListener = InternalRumSessionProvider
+            val combinedListener = CombinedRumSessionListener(internalSessionListener, userSessionListener)
+
+            platformBuilder.setSessionListener(combinedListener)
+
             return RumConfiguration(platformBuilder.build())
         }
 

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumSessionProvider.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumSessionProvider.kt
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration
+
+import kotlin.concurrent.Volatile
+
+internal object InternalRumSessionProvider : RumSessionProvider, RumSessionListener {
+
+    @Volatile
+    override var sessionId: String? = null
+        private set
+
+    override fun onSessionStarted(sessionId: String, isDiscarded: Boolean) {
+        this.sessionId = if (isDiscarded) {
+            null
+        } else {
+            sessionId
+        }
+    }
+}
+
+interface RumSessionProvider {
+
+    val sessionId: String?
+
+    companion object {
+        /**
+         * This is internal API and shouldn't be used by the clients.
+         */
+        fun get(): RumSessionProvider = InternalRumSessionProvider
+    }
+}

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/internal/CombinedRumSessionListener.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/internal/CombinedRumSessionListener.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.configuration.internal
+
+import com.datadog.kmp.rum.configuration.RumSessionListener
+
+internal class CombinedRumSessionListener(
+    private val internalListener: RumSessionListener,
+    internal val userListener: RumSessionListener?
+) : RumSessionListener {
+    override fun onSessionStarted(sessionId: String, isDiscarded: Boolean) {
+        internalListener.onSessionStarted(sessionId, isDiscarded)
+        userListener?.onSessionStarted(sessionId, isDiscarded)
+    }
+}

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
@@ -12,6 +12,7 @@ import com.datadog.kmp.ktor.internal.sampling.DeterministicTraceSampler
 import com.datadog.kmp.ktor.internal.trace.DefaultSpanIdGenerator
 import com.datadog.kmp.ktor.internal.trace.DefaultTraceIdGenerator
 import com.datadog.kmp.rum.RumMonitor
+import com.datadog.kmp.rum.configuration.RumSessionProvider
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.api.ClientPlugin
 
@@ -38,6 +39,7 @@ fun datadogKtorPlugin(
 ): ClientPlugin<Unit> {
     return DatadogKtorPlugin(
         RumMonitor.get(),
+        RumSessionProvider.get(),
         tracedHosts,
         DeterministicTraceSampler(traceSampleRate),
         traceContextInjection,

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaderType.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaderType.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.kmp.ktor
 
+import com.datadog.kmp.ktor.internal.addToW3cBaggage
 import com.datadog.kmp.ktor.internal.trace.SpanId
 import com.datadog.kmp.ktor.internal.trace.TraceId
 import io.ktor.client.request.HttpRequestBuilder
@@ -41,12 +42,14 @@ enum class TracingHeaderType {
      * @param sampledIn whether the trace is sampled in
      * @param traceId the trace id
      * @param spanId the span id
+     * @param rumSessionId the RUM session id
      */
     internal fun injectHeaders(
         request: HttpRequestBuilder,
         sampledIn: Boolean,
         traceId: TraceId,
-        spanId: SpanId
+        spanId: SpanId,
+        rumSessionId: String?
     ) {
         request.headers {
             when (this@TracingHeaderType) {
@@ -103,6 +106,10 @@ enum class TracingHeaderType {
                     val decision = if (sampledIn) W3C_SAMPLE_PRIORITY_ACCEPT else W3C_SAMPLE_PRIORITY_DROP
                     append(W3C_TRACEPARENT_KEY, "00-$paddedTraceId-$paddedSpanId-$decision")
                 }
+            }
+
+            if (rumSessionId != null) {
+                addToW3cBaggage(DATADOG_RUM_SESSION_ID_TAG, rumSessionId)
             }
         }
     }

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaders.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaders.kt
@@ -16,6 +16,7 @@ internal const val DATADOG_KEEP_SAMPLING_DECISION = "1"
 internal const val DATADOG_ORIGIN_KEY = "x-datadog-origin"
 internal const val DATADOG_ORIGIN_RUM = "rum"
 internal const val DATADOG_MOST_SIGNIFICANT_TRACE_ID_TAG = "_dd.p.tid"
+internal const val DATADOG_RUM_SESSION_ID_TAG = "session.id"
 
 // taken from B3HttpCodec
 internal const val B3_HEADER_KEY = "b3"
@@ -31,6 +32,7 @@ internal const val B3M_KEEP_SAMPLING_DECISION = "1"
 // taken from W3CHttpCodec
 internal const val W3C_TRACEPARENT_KEY = "traceparent"
 internal const val W3C_TRACESTATE_KEY = "tracestate"
+internal const val W3C_BAGGAGE_KEY = "baggage"
 
 // https://www.w3.org/TR/trace-context/#traceparent-header
 internal const val W3C_TRACEPARENT_DROP_SAMPLING_DECISION = "00-%s-%s-00"

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/HeadersExt.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/HeadersExt.kt
@@ -1,0 +1,80 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+@file:Suppress("MatchingDeclarationName")
+
+package com.datadog.kmp.ktor.internal
+
+import com.datadog.kmp.ktor.W3C_BAGGAGE_KEY
+import io.ktor.http.HeadersBuilder
+
+internal data class BaggageItem(val key: String, val value: String, val metadata: String? = null) {
+    fun toHeaderString(): String {
+        return if (metadata != null) {
+            "$key=$value;$metadata"
+        } else {
+            "$key=$value"
+        }
+    }
+}
+
+internal fun HeadersBuilder.w3cBaggage(): List<List<BaggageItem>>? {
+    // baggage value can be split in multiple headers
+    val existingHeaders = getAll(W3C_BAGGAGE_KEY) ?: return null
+    return existingHeaders
+        .map {
+            it.split(",")
+                // note: very simple parsing, without edge-cases, may be not 100% compliant with the spec
+                // it doesn't handle non-ASCII character encoding, because we are not going to read/modify such
+                // anyway in our flow
+                .filter { it.contains("=") }
+                .map {
+                    val keyValueDelimiterIndex = it.indexOf('=')
+                    val key = it.substring(0, keyValueDelimiterIndex).trim()
+                    val value = it.substring(keyValueDelimiterIndex + 1).trim()
+                    val metaIndex = value.indexOf(";")
+                    if (metaIndex != -1) {
+                        val metadata = value.substring(metaIndex + 1).trim()
+                        BaggageItem(key, value.substring(0, metaIndex), metadata)
+                    } else {
+                        BaggageItem(key, value)
+                    }
+                }
+        }
+}
+
+internal fun HeadersBuilder.addToW3cBaggage(key: String, value: String) {
+    val existingBaggage = w3cBaggage()
+    if (existingBaggage == null) {
+        append(W3C_BAGGAGE_KEY, "$key=$value")
+    } else {
+        remove(W3C_BAGGAGE_KEY)
+        // https://www.w3.org/TR/baggage/#baggage-string
+        // >> Uniqueness of keys between multiple list-members in a baggage-string is not guaranteed.
+        // >> The order of duplicate entries SHOULD be preserved when mutating the list. Producers SHOULD try
+        // >> to produce a baggage-string without any list-members which duplicate the key of another list member.
+        val headersWithGivenKey =
+            existingBaggage.filter { it.any { it.key == key } }
+        val updatedBaggage = if (headersWithGivenKey.isNotEmpty()) {
+            existingBaggage.map {
+                it.map {
+                    if (it.key == key) it.copy(value = value, metadata = null) else it
+                }
+            }
+        } else {
+            existingBaggage.toMutableList().apply {
+                add(removeLastOrNull().orEmpty().toMutableList().apply { add(BaggageItem(key, value)) })
+            }
+        }
+        updatedBaggage
+            .forEach {
+                append(
+                    W3C_BAGGAGE_KEY,
+                    it.joinToString(separator = ",") { it.toHeaderString() }
+                )
+            }
+    }
+}

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
@@ -22,6 +22,7 @@ import com.datadog.kmp.ktor.internal.trace.TraceIdGenerator
 import com.datadog.kmp.rum.RumMonitor
 import com.datadog.kmp.rum.RumResourceKind
 import com.datadog.kmp.rum.RumResourceMethod
+import com.datadog.kmp.rum.configuration.RumSessionProvider
 import io.ktor.client.plugins.api.OnRequestContext
 import io.ktor.client.plugins.api.OnResponseContext
 import io.ktor.client.request.HttpRequestBuilder
@@ -34,6 +35,7 @@ import io.ktor.util.AttributeKey
 
 internal class DatadogKtorPlugin(
     private val rumMonitor: RumMonitor,
+    private val rumSessionProvider: RumSessionProvider,
     private val tracedHosts: Map<String, Set<TracingHeaderType>>,
     private val traceSampler: Sampler<TraceId>,
     private val traceContextInjection: TraceContextInjection,
@@ -57,7 +59,7 @@ internal class DatadogKtorPlugin(
 
         if (isSampledIn && traceHeaderTypes.isNotEmpty()) {
             traceHeaderTypes.forEach { headerType ->
-                headerType.injectHeaders(request, true, traceId, spanId)
+                headerType.injectHeaders(request, true, traceId, spanId, rumSessionProvider.sessionId)
             }
             request.attributes.put(DD_TRACE_ID_ATTR, traceId)
             request.attributes.put(DD_SPAN_ID_ATTR, spanId)
@@ -65,7 +67,7 @@ internal class DatadogKtorPlugin(
         } else {
             if (traceContextInjection == TraceContextInjection.All) {
                 traceHeaderTypes.forEach { headerType ->
-                    headerType.injectHeaders(request, false, traceId, spanId)
+                    headerType.injectHeaders(request, false, traceId, spanId, rumSessionProvider.sessionId)
                 }
             }
         }

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/TracingHeaderTypeTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/TracingHeaderTypeTest.kt
@@ -6,42 +6,55 @@
 
 package com.datadog.kmp.ktor
 
+import com.benasher44.uuid.uuid4
 import com.datadog.kmp.ktor.internal.trace.SpanId
 import com.datadog.kmp.ktor.internal.trace.TraceId
+import com.datadog.tools.random.nullable
 import io.ktor.client.request.HttpRequestBuilder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class TracingHeaderTypeTest {
 
+    private var fakeRumSessionId = nullable(uuid4().toString())
+
     @Test
     fun `M inject Datadog headers W injectHeaders`() {
         // Given
         val expectedHeaders = mapOf(
-            Fixture(TraceId(0u, 1337u), SpanId(42u), true) to mapOf(
-                "x-datadog-parent-id" to "42",
-                "x-datadog-trace-id" to "1337",
-                "x-datadog-tags" to "_dd.p.tid=0",
-                "x-datadog-sampling-priority" to "1",
-                "x-datadog-origin" to "rum"
-            ),
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true) to mapOf(
-                "x-datadog-parent-id" to "42",
-                "x-datadog-trace-id" to "1337",
-                "x-datadog-tags" to "_dd.p.tid=499602d2",
-                "x-datadog-sampling-priority" to "1",
-                "x-datadog-origin" to "rum"
-            ),
-            Fixture(TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE), SpanId(ULong.MAX_VALUE), true) to mapOf(
-                "x-datadog-parent-id" to "18446744073709551615",
-                "x-datadog-trace-id" to "18446744073709551615",
-                "x-datadog-tags" to "_dd.p.tid=ffffffffffffffff",
-                "x-datadog-sampling-priority" to "1",
-                "x-datadog-origin" to "rum"
-            ),
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false) to mapOf(
-                "x-datadog-sampling-priority" to "0"
-            )
+            Fixture(TraceId(0u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+                put("x-datadog-parent-id", "42")
+                put("x-datadog-trace-id", "1337")
+                put("x-datadog-tags", "_dd.p.tid=0")
+                put("x-datadog-sampling-priority", "1")
+                put("x-datadog-origin", "rum")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+                put("x-datadog-parent-id", "42")
+                put("x-datadog-trace-id", "1337")
+                put("x-datadog-tags", "_dd.p.tid=499602d2")
+                put("x-datadog-sampling-priority", "1")
+                put("x-datadog-origin", "rum")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(
+                TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
+                SpanId(ULong.MAX_VALUE),
+                true,
+                fakeRumSessionId
+            ) to buildMap {
+                put("x-datadog-parent-id", "18446744073709551615")
+                put("x-datadog-trace-id", "18446744073709551615")
+                put("x-datadog-tags", "_dd.p.tid=ffffffffffffffff")
+                put("x-datadog-sampling-priority", "1")
+                put("x-datadog-origin", "rum")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false, fakeRumSessionId) to buildMap {
+                put("x-datadog-sampling-priority", "0")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            }
         )
 
         // When + Then
@@ -51,7 +64,8 @@ class TracingHeaderTypeTest {
                 fakeRequestBuilder,
                 it.key.sampledIn,
                 it.key.traceId,
-                it.key.spanId
+                it.key.spanId,
+                it.key.rumSessionId
             )
             val headers = fakeRequestBuilder.headers.entries()
                 .associate {
@@ -66,18 +80,27 @@ class TracingHeaderTypeTest {
     fun `M inject TraceContext headers W injectHeaders`() {
         // Given
         val expectedHeaders = mapOf(
-            Fixture(TraceId(0u, 1337u), SpanId(42u), true) to mapOf(
-                "traceparent" to "00-00000000000000000000000000000539-000000000000002a-01"
-            ),
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true) to mapOf(
-                "traceparent" to "00-00000000499602d20000000000000539-000000000000002a-01"
-            ),
-            Fixture(TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE), SpanId(ULong.MAX_VALUE), true) to mapOf(
-                "traceparent" to "00-ffffffffffffffffffffffffffffffff-ffffffffffffffff-01"
-            ),
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false) to mapOf(
-                "traceparent" to "00-00000000499602d20000000000000539-000000000000002a-00"
-            )
+            Fixture(TraceId(0u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+                put("traceparent", "00-00000000000000000000000000000539-000000000000002a-01")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+                put("traceparent", "00-00000000499602d20000000000000539-000000000000002a-01")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(
+                TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
+                SpanId(ULong.MAX_VALUE),
+                true,
+                fakeRumSessionId
+            ) to buildMap {
+                put("traceparent", "00-ffffffffffffffffffffffffffffffff-ffffffffffffffff-01")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false, fakeRumSessionId) to buildMap {
+                put("traceparent", "00-00000000499602d20000000000000539-000000000000002a-00")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            }
         )
 
         // When + Then
@@ -87,7 +110,8 @@ class TracingHeaderTypeTest {
                 fakeRequestBuilder,
                 it.key.sampledIn,
                 it.key.traceId,
-                it.key.spanId
+                it.key.spanId,
+                it.key.rumSessionId
             )
             val headers = fakeRequestBuilder.headers.entries()
                 .associate {
@@ -102,18 +126,27 @@ class TracingHeaderTypeTest {
     fun `M inject B3 headers W injectHeaders`() {
         // Given
         val expectedHeaders = mapOf(
-            Fixture(TraceId(0u, 1337u), SpanId(42u), true) to mapOf(
-                "b3" to "539-2a-1"
-            ),
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true) to mapOf(
-                "b3" to "499602d20000000000000539-2a-1"
-            ),
-            Fixture(TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE), SpanId(ULong.MAX_VALUE), true) to mapOf(
-                "b3" to "ffffffffffffffffffffffffffffffff-ffffffffffffffff-1"
-            ),
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false) to mapOf(
-                "b3" to "0"
-            )
+            Fixture(TraceId(0u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+                put("b3", "539-2a-1")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+                put("b3", "499602d20000000000000539-2a-1")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(
+                TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
+                SpanId(ULong.MAX_VALUE),
+                true,
+                fakeRumSessionId
+            ) to buildMap {
+                put("b3", "ffffffffffffffffffffffffffffffff-ffffffffffffffff-1")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false, fakeRumSessionId) to buildMap {
+                put("b3", "0")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            }
         )
 
         // When + Then
@@ -123,7 +156,8 @@ class TracingHeaderTypeTest {
                 fakeRequestBuilder,
                 it.key.sampledIn,
                 it.key.traceId,
-                it.key.spanId
+                it.key.spanId,
+                it.key.rumSessionId
             )
             val headers = fakeRequestBuilder.headers.entries()
                 .associate {
@@ -138,24 +172,33 @@ class TracingHeaderTypeTest {
     fun `M inject B3Multi headers W injectHeaders`() {
         // Given
         val expectedHeaders = mapOf(
-            Fixture(TraceId(0u, 1337u), SpanId(42u), true) to mapOf(
-                "X-B3-TraceId" to "539",
-                "X-B3-SpanId" to "2a",
-                "X-B3-Sampled" to "1"
-            ),
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true) to mapOf(
-                "X-B3-TraceId" to "499602d20000000000000539",
-                "X-B3-SpanId" to "2a",
-                "X-B3-Sampled" to "1"
-            ),
-            Fixture(TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE), SpanId(ULong.MAX_VALUE), true) to mapOf(
-                "X-B3-TraceId" to "ffffffffffffffffffffffffffffffff",
-                "X-B3-SpanId" to "ffffffffffffffff",
-                "X-B3-Sampled" to "1"
-            ),
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false) to mapOf(
-                "X-B3-Sampled" to "0"
-            )
+            Fixture(TraceId(0u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+                put("X-B3-TraceId", "539")
+                put("X-B3-SpanId", "2a")
+                put("X-B3-Sampled", "1")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+                put("X-B3-TraceId", "499602d20000000000000539")
+                put("X-B3-SpanId", "2a")
+                put("X-B3-Sampled", "1")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(
+                TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
+                SpanId(ULong.MAX_VALUE),
+                true,
+                fakeRumSessionId
+            ) to buildMap {
+                put("X-B3-TraceId", "ffffffffffffffffffffffffffffffff")
+                put("X-B3-SpanId", "ffffffffffffffff")
+                put("X-B3-Sampled", "1")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            },
+            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false, fakeRumSessionId) to buildMap {
+                put("X-B3-Sampled", "0")
+                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+            }
         )
 
         // When + Then
@@ -165,7 +208,8 @@ class TracingHeaderTypeTest {
                 fakeRequestBuilder,
                 it.key.sampledIn,
                 it.key.traceId,
-                it.key.spanId
+                it.key.spanId,
+                it.key.rumSessionId
             )
             val headers = fakeRequestBuilder.headers.entries()
                 .associate {
@@ -181,7 +225,8 @@ class TracingHeaderTypeTest {
     private data class Fixture(
         val traceId: TraceId,
         val spanId: SpanId,
-        val sampledIn: Boolean
+        val sampledIn: Boolean,
+        val rumSessionId: String? = null
     )
 
     // endregion

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/HeadersExtTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/HeadersExtTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.ktor.internal
+
+import io.ktor.http.HeadersBuilder
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class HeadersExtTest {
+
+    @Test
+    fun `M parse baggage header W w3cBaggage`() {
+        // https://www.w3.org/TR/baggage/#examples-of-http-headers
+        // Given
+        val headers = HeadersBuilder().apply {
+            append(
+                "baggage",
+                "key1=value1;property1;property2, key2 = value2, key3=value3; propertyKey=propertyValue"
+            )
+            append("baggage", "anotherKey=anotherValue")
+            append("baggage", "userId=alice,serverNode=DF%2028,isProduction=false")
+        }
+
+        // When
+        val parsed = headers.w3cBaggage()
+
+        // Then
+        assertNotNull(parsed)
+        assertEquals(3, parsed.size)
+        val firstBaggage = parsed[0]
+        val secondBaggage = parsed[1]
+        val thirdBaggage = parsed[2]
+        assertEquals(
+            listOf(
+                BaggageItem("key1", "value1", "property1;property2"),
+                BaggageItem("key2", "value2"),
+                BaggageItem("key3", "value3", "propertyKey=propertyValue")
+            ),
+            firstBaggage
+        )
+        assertEquals(
+            listOf(BaggageItem("anotherKey", "anotherValue")),
+            secondBaggage
+        )
+        assertEquals(
+            listOf(
+                BaggageItem("userId", "alice"),
+                BaggageItem("serverNode", "DF%2028"),
+                BaggageItem("isProduction", "false")
+            ),
+            thirdBaggage
+        )
+    }
+
+    @Test
+    fun `M parse baggage header W w3cBaggage + no baggage header`() {
+        // Given
+        val headers = HeadersBuilder()
+
+        // When
+        val parsed = headers.w3cBaggage()
+
+        // Then
+        assertNull(parsed)
+    }
+
+    @Test
+    fun `M update existing baggage header W addToW3cBaggage + key is missing`() {
+        // Given
+        val fakeBaggageHeader1 = "key1=value1;property1;property2=value2,key2=value3;property3;property4=value4"
+        val fakeBaggageHeader2 = "key3=value5;property5,key4=value6;property6"
+        val headers = HeadersBuilder().apply {
+            append("baggage", fakeBaggageHeader1)
+            append("baggage", fakeBaggageHeader2)
+        }
+
+        // When + Then
+        headers.addToW3cBaggage("newKey", "newValue")
+        val baggageHeaders = headers.getAll("baggage")
+        assertNotNull(baggageHeaders)
+        assertEquals(2, baggageHeaders.size)
+        assertEquals(fakeBaggageHeader1, baggageHeaders.first())
+        assertEquals("$fakeBaggageHeader2,newKey=newValue", baggageHeaders.last())
+    }
+
+    @Test
+    fun `M update existing baggage header W addToW3cBaggage + key is missing + empty baggage value`() {
+        // Given
+        val headers = HeadersBuilder().apply {
+            append("baggage", "")
+        }
+
+        // When + Then
+        headers.addToW3cBaggage("newKey", "newValue")
+        val baggageHeaders = headers.getAll("baggage")
+        assertNotNull(baggageHeaders)
+        assertEquals(1, baggageHeaders.size)
+        assertEquals("newKey=newValue", baggageHeaders.first())
+    }
+
+    @Test
+    fun `M update existing baggage header W addToW3cBaggage + key exists`() {
+        // Given
+        val fakeBaggageHeader1 = "key1=value1;property1;property2=value2,key2=value3;property3;property4=value4"
+        val fakeBaggageHeader2 = "key3=value5;property5,existingKey=oldValue;property1,key4=value6;property6"
+        val headers = HeadersBuilder().apply {
+            append("baggage", fakeBaggageHeader1)
+            append("baggage", fakeBaggageHeader2)
+        }
+
+        // When + Then
+        headers.addToW3cBaggage(
+            "existingKey",
+            "newValue"
+        )
+        val baggageHeaders = headers.getAll("baggage")
+        assertNotNull(baggageHeaders)
+        assertEquals(2, baggageHeaders.size)
+        assertEquals(fakeBaggageHeader1, baggageHeaders.first())
+        assertEquals(
+            fakeBaggageHeader2.replace(
+                "oldValue;property1",
+                "newValue"
+            ),
+            baggageHeaders.last()
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds RUM Session ID to the trace context propagation headers in the Ktor instrumentation by introducing [W3C baggage](https://www.w3.org/TR/baggage) header.

This header is attached irrespective of the propagation style selected.

Implementation supports mutation of the existing `baggage` header instead of completely erasing it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

