### PR TITLE
Fix flaky `DefaultSwiftUIRUMActionsPredicateTest`

### DIFF
--- a/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/tracking/DefaultSwiftUIRUMActionsPredicateTest.kt
+++ b/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/tracking/DefaultSwiftUIRUMActionsPredicateTest.kt
@@ -7,24 +7,46 @@
 package com.datadog.kmp.rum.tracking
 
 import com.datadog.tools.random.randomBoolean
+import kotlinx.cinterop.useContents
+import platform.Foundation.NSProcessInfo
+import platform.UIKit.UIDevice
+import platform.UIKit.UIUserInterfaceIdiomPad
+import platform.UIKit.UIUserInterfaceIdiomPhone
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DefaultSwiftUIRUMActionsPredicateTest {
 
     @Test
-    fun `M call native default SwiftUI RUM actions predicate W createView`() {
+    fun `M call native default SwiftUI RUM actions predicate W createAction`() {
         // Given
-        val testedInstance = DefaultSwiftUIRUMActionsPredicate(randomBoolean())
+        val fakeLegacyDetectionEnabled = randomBoolean()
+        val testedInstance = DefaultSwiftUIRUMActionsPredicate(fakeLegacyDetectionEnabled)
         val fakeSwiftUIComponentName = "fake-swiftui-component"
 
         // When
         val rumAction = testedInstance.createAction(fakeSwiftUIComponentName)
 
         // Then
-        checkNotNull(rumAction)
-        assertEquals(fakeSwiftUIComponentName, rumAction.name)
-        assertTrue(rumAction.attributes.isEmpty())
+        val majorVersion = NSProcessInfo.processInfo.operatingSystemVersion.useContents { majorVersion }
+        val isIOS = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone ||
+            UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad
+        val isIOS18OrLater = isIOS && majorVersion >= 18
+
+        if (isIOS) {
+            if (isIOS18OrLater || fakeLegacyDetectionEnabled) {
+                checkNotNull(rumAction)
+                assertEquals(fakeSwiftUIComponentName, rumAction.name)
+                assertTrue(rumAction.attributes.isEmpty())
+            } else {
+                assertNull(rumAction)
+            }
+        } else {
+            checkNotNull(rumAction)
+            assertEquals(fakeSwiftUIComponentName, rumAction.name)
+            assertTrue(rumAction.attributes.isEmpty())
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes flaky `DefaultSwiftUIRUMActionsPredicateTest`, because there is a [condition](https://github.com/DataDog/dd-sdk-ios/blob/c0ed83c5041b1495a93b6a154b64d0661172e0f0/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIRUMActionsPredicate.swift#L38-L43) in the underlying code under test.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

