### PR TITLE
RUM-10485: Add `LogEvent.accountInfo` property mapping for iOS models

### DIFF
--- a/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/configuration/internal/IOSLogsConfigurationBuilder.kt
+++ b/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/configuration/internal/IOSLogsConfigurationBuilder.kt
@@ -40,7 +40,9 @@ internal class IOSLogsConfigurationBuilder : PlatformLogsConfigurationBuilder<DD
                 logEvent.userInfo().setExtraInfo(eraseKeyType(it))
             }
 
-            // TODO RUM-10485 LogEvent.account is missing in iOS SDK ObjC API
+            mapped.account?.additionalProperties?.let {
+                logEvent.accountInfo()?.setExtraInfo(eraseKeyType(it))
+            }
 
             logEvent
         }

--- a/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/model/internal/LogEventMappingExt.kt
+++ b/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/model/internal/LogEventMappingExt.kt
@@ -7,6 +7,7 @@
 package com.datadog.kmp.log.model.internal
 
 import cocoapods.DatadogLogs.DDLogEvent
+import cocoapods.DatadogLogs.DDLogEventAccountInfo
 import cocoapods.DatadogLogs.DDLogEventDd
 import cocoapods.DatadogLogs.DDLogEventDevice
 import cocoapods.DatadogLogs.DDLogEventError
@@ -34,7 +35,7 @@ internal fun DDLogEvent.toCommonModel(): LogEvent = LogEvent(
     ),
     dd = dd().toCommonModel(),
     usr = userInfo().toCommonModel(),
-    // TODO RUM-10485 LogEvent.account is missing in iOS SDK ObjC API
+    account = accountInfo()?.toCommonModel(),
     // TODO RUM-6098 The way network/carrier information is passed varies a lot between Android and iOS, removing it
     //  from the model for now
     error = error()?.toCommonModel(),
@@ -69,6 +70,12 @@ internal fun DDLogEventUserInfo.toCommonModel(): LogEvent.Usr = LogEvent.Usr(
     id = id(),
     name = name(),
     email = email(),
+    additionalProperties = extraInfo().mapKeys { it.key as String }.toMutableMap()
+)
+
+internal fun DDLogEventAccountInfo.toCommonModel(): LogEvent.Account = LogEvent.Account(
+    id = id(),
+    name = name(),
     additionalProperties = extraInfo().mapKeys { it.key as String }.toMutableMap()
 )
 


### PR DESCRIPTION
### What does this PR do?

This is a continuation for the fix made in iOS SDK https://github.com/DataDog/dd-sdk-ios/pull/2360.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

