### PR TITLE
Bump language version to 2.0, align `copy()` method visibility for public classes with internal constructor

### DIFF
--- a/core/src/androidUnitTest/kotlin/com/datadog/kmp/tools/unit/extensions/TestConfigurationExtension.kt
+++ b/core/src/androidUnitTest/kotlin/com/datadog/kmp/tools/unit/extensions/TestConfigurationExtension.kt
@@ -132,7 +132,7 @@ class TestConfigurationExtension :
                 it.isAnnotationPresent(TestConfigurationsProvider::class.java)
             }
         if (clazz.superclass != null) {
-            collectProviderMethods(clazz.superclass, accumulator)
+            collectProviderMethods(clazz.superclass as Class<*>, accumulator)
         }
     }
 

--- a/core/src/commonMain/kotlin/com/datadog/kmp/core/configuration/Configuration.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/core/configuration/Configuration.kt
@@ -14,6 +14,7 @@ import com.datadog.kmp.DatadogSite
  *
  * This is necessary to initialize the SDK with the [Datadog.initialize] method.
  */
+@ConsistentCopyVisibility
 data class Configuration
 internal constructor(
     internal val coreConfig: Core,

--- a/features/session-replay/src/commonMain/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfiguration.kt
+++ b/features/session-replay/src/commonMain/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfiguration.kt
@@ -11,6 +11,7 @@ import com.datadog.kmp.sessionreplay.configuration.internal.PlatformSessionRepla
 /**
  * Describes configuration to be used for the Session Replay feature.
  */
+@ConsistentCopyVisibility
 data class SessionReplayConfiguration internal constructor(
     internal val nativeConfiguration: Any
 ) {

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/config/DatadogBuildConfigExtension.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/config/DatadogBuildConfigExtension.kt
@@ -20,4 +20,4 @@ internal val DatadogBuildConfigExtension.jvmTargetOrDefault
     get() = jvmTarget.getOrElse(JvmTarget.JVM_17)
 
 internal val DatadogBuildConfigExtension.kotlinVersionOrDefault
-    get() = kotlinVersion.getOrElse(KotlinVersion.KOTLIN_1_9)
+    get() = kotlinVersion.getOrElse(KotlinVersion.KOTLIN_2_0)


### PR DESCRIPTION
### What does this PR do?

This change bumps language version to 2.0 and adds `@ConsistentCopyVisibility` annotation to the public data classes with `internal` primary constructor to make `copy()` method `internal` as well.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

