### PR TITLE
RUM-6390: Add API to measure view loading time

### DIFF
--- a/features/rum/api/commonMain/apiSurface
+++ b/features/rum/api/commonMain/apiSurface
@@ -34,6 +34,7 @@ interface com.datadog.kmp.rum.RumMonitor
   fun startFeatureOperation(String, String? = null, Map<String, Any?> = emptyMap())
   fun succeedFeatureOperation(String, String? = null, Map<String, Any?> = emptyMap())
   fun failFeatureOperation(String, String? = null, com.datadog.kmp.rum.featureoperations.FailureReason, Map<String, Any?> = emptyMap())
+  fun addViewLoadingTime(Boolean)
   fun stopSession()
   var debug: Boolean
   companion object 

--- a/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapter.kt
+++ b/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapter.kt
@@ -139,6 +139,11 @@ internal class RumMonitorAdapter(private val nativeRumMonitor: NativeRumMonitor)
         nativeRumMonitor.failFeatureOperation(name, operationKey, failureReason.native, attributes)
     }
 
+    @OptIn(NativeExperimentalRumApi::class, ExperimentalRumApi::class)
+    override fun addViewLoadingTime(overwrite: Boolean) {
+        nativeRumMonitor.addViewLoadingTime(overwrite)
+    }
+
     override fun stopSession() {
         nativeRumMonitor.stopSession()
     }

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
@@ -402,6 +402,18 @@ class RumMonitorAdapterTest {
         )
     }
 
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M call native addViewLoadingTime W addViewLoadingTime`(
+        @BoolForgery fakeOverwrite: Boolean
+    ) {
+        // When
+        testedRumMonitorAdapter.addViewLoadingTime(fakeOverwrite)
+
+        // Then
+        verify(mockNativeRumMonitor).addViewLoadingTime(fakeOverwrite)
+    }
+
     @Test
     fun `M call native stopSession W stopSession`() {
         // When

--- a/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/internal/DDRumMonitorProxy.kt
+++ b/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/internal/DDRumMonitorProxy.kt
@@ -154,6 +154,8 @@ internal interface DDRumMonitorProxy {
         attributes: Map<Any?, *>
     )
 
+    fun addViewLoadingTime(overwrite: Boolean)
+
     companion object {
         fun create(nativeRumMonitor: DDRUMMonitor): DDRumMonitorProxy = object : DDRumMonitorProxy {
             override fun addActionWithType(
@@ -288,6 +290,9 @@ internal interface DDRumMonitorProxy {
                 failureReason: DDRUMFeatureOperationFailureReason,
                 attributes: Map<Any?, *>
             ) = nativeRumMonitor.failFeatureOperationWithName(name, operationKey, failureReason, attributes)
+
+            override fun addViewLoadingTime(overwrite: Boolean) =
+                nativeRumMonitor.addViewLoadingTimeWithOverwrite(overwrite)
         }
     }
 }

--- a/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapter.kt
+++ b/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapter.kt
@@ -210,6 +210,11 @@ internal class RumMonitorAdapter(
         nativeRumMonitor.failFeatureOperation(name, operationKey, failureReason.native, eraseKeyType(attributes))
     }
 
+    @OptIn(ExperimentalRumApi::class)
+    override fun addViewLoadingTime(overwrite: Boolean) {
+        nativeRumMonitor.addViewLoadingTime(overwrite)
+    }
+
     override fun stopSession() {
         nativeRumMonitor.stopSession()
     }

--- a/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
+++ b/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
@@ -552,6 +552,20 @@ class RumMonitorAdapterTest {
     }
 
     @Test
+    fun `M call native addViewLoadingTime W addViewLoadingTime`() {
+        // Given
+        val fakeOverwrite = randomBoolean()
+
+        // When
+        testedRumMonitorAdapter.addViewLoadingTime(fakeOverwrite)
+
+        // Then
+        verify {
+            mockNativeRumMonitor.addViewLoadingTime(fakeOverwrite)
+        }
+    }
+
+    @Test
     fun `M call native stopSession W stopSession`() {
         // When
         testedRumMonitorAdapter.stopSession()

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/RumMonitor.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/RumMonitor.kt
@@ -272,12 +272,12 @@ interface RumMonitor {
     )
 
     /**
-     * Adds view loading time RUM active view based on the time elapsed since the view was started.
+     * Adds view loading time to the active view based on the time elapsed since the view was started.
      * The view loading time is automatically calculated as the difference between the current time
      * and the start time of the view.
      * This method should be called only once per view.
      * If no view is started or active, this method does nothing.
-     * @param overwrite which controls if the method overwrites the previously calculated view loading time.
+     * @param overwrite controls if the method overwrites the previously calculated view loading time.
      */
     @ExperimentalRumApi
     fun addViewLoadingTime(overwrite: Boolean)

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/RumMonitor.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/RumMonitor.kt
@@ -272,6 +272,17 @@ interface RumMonitor {
     )
 
     /**
+     * Adds view loading time RUM active view based on the time elapsed since the view was started.
+     * The view loading time is automatically calculated as the difference between the current time
+     * and the start time of the view.
+     * This method should be called only once per view.
+     * If no view is started or active, this method does nothing.
+     * @param overwrite which controls if the method overwrites the previously calculated view loading time.
+     */
+    @ExperimentalRumApi
+    fun addViewLoadingTime(overwrite: Boolean)
+
+    /**
      * Stops the current session.
      * A new session will start in response to a call to [startView], [addAction], or
      * [startAction]. If the session is started because of a call to [addAction],


### PR DESCRIPTION
### What does this PR do?

This PR adds `RumMonitor.addViewLoadingTime` API similar to iOS and Android SDKs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

