### PR TITLE
RUM-5176: Use sync methods to write error to RUM/Logs during the crash on Apple platforms

### DIFF
--- a/core/src/appleMain/kotlin/com/datadog/kmp/internal/RuntimeExt.kt
+++ b/core/src/appleMain/kotlin/com/datadog/kmp/internal/RuntimeExt.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.kmp.internal
 
-import platform.posix.usleep
 import kotlin.concurrent.AtomicReference
 import kotlin.experimental.ExperimentalNativeApi
 
@@ -37,12 +36,6 @@ internal fun addDatadogUnhandledExceptionHookWithTermination(
             // hook processing order: C -> B -> A
             val canCrash = getUnhandledExceptionHook() == this
             if (canCrash) {
-                // TODO RUM-5176 RumMonitor.addErrorWithError call is not blocking, so we may have no time to
-                //  write a specific error and we will end up with having a generic runtime crash error. Adding
-                //  a small sleep call here won't hurt: we get better chances that error is written
-                val sleepMicroseconds = 80_000U // 80 ms
-                usleep(sleepMicroseconds)
-
                 // our hook is the last one, we can terminate application, otherwise we shift this
                 // responsibility to other hooks upper in the chain
                 terminateAction(throwable)

--- a/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/Logs.kt
+++ b/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/Logs.kt
@@ -10,6 +10,7 @@ import cocoapods.DatadogLogs.DDLogger
 import cocoapods.DatadogLogs.DDLoggerConfiguration
 import cocoapods.DatadogLogs.DDLogs
 import cocoapods.DatadogLogs.DDLogsConfiguration
+import cocoapods.DatadogLogs._internal_sync_criticalWithMessage
 import com.datadog.kmp.internal.INCLUDE_BINARY_IMAGES
 import com.datadog.kmp.internal.InternalProxy
 import com.datadog.kmp.internal.LOG_ERROR_IS_CRASH
@@ -42,7 +43,7 @@ actual object Logs {
                 // TODO RUM-5178 No ObjC API to write crash log directly, without any logger
                 val crashLogger = DDLogger.createWith(loggerConfiguration)
 
-                crashLogger.critical(
+                crashLogger._internal_sync_criticalWithMessage(
                     "Caught unhandled Kotlin exception",
                     createNSErrorFromThrowable(it),
                     mutableMapOf<Any?, Any?>().apply {

--- a/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/Rum.kt
+++ b/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/Rum.kt
@@ -10,6 +10,7 @@ import cocoapods.DatadogRUM.DDRUM
 import cocoapods.DatadogRUM.DDRUMConfiguration
 import cocoapods.DatadogRUM.DDRUMErrorSourceSource
 import cocoapods.DatadogRUM.DDRUMMonitor
+import cocoapods.DatadogRUM._internal_sync_addError
 import com.datadog.kmp.internal.INCLUDE_BINARY_IMAGES
 import com.datadog.kmp.internal.InternalProxy
 import com.datadog.kmp.internal.RUM_ERROR_IS_CRASH
@@ -33,7 +34,7 @@ actual object Rum {
         if (InternalProxy.isCrashReportingEnabled) {
             addDatadogUnhandledExceptionHook {
                 DDRUMMonitor.shared()
-                    .addErrorWithError(
+                    ._internal_sync_addError(
                         createNSErrorFromThrowable(it),
                         DDRUMErrorSourceSource,
                         mutableMapOf<Any?, Any?>().apply {


### PR DESCRIPTION
### What does this PR do?

This PR drops an artificial delay which was used to give some time to write errors to RUM/Logs during the runtime crash, because sync methods were kindly added by @maxep in https://github.com/DataDog/dd-sdk-ios/pull/2414 which guarantee that error is written by the time these method return.

That change will reduce the percentage of unreported errors.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

