### PR TITLE
Report RUM session stop

### DIFF
--- a/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/RumMonitor.kt
+++ b/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/RumMonitor.kt
@@ -7,8 +7,12 @@
 package com.datadog.kmp.rum
 
 import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.kmp.rum.configuration.InternalRumSessionProviderListener
 import com.datadog.kmp.rum.internal.RumMonitorAdapter
 
 internal actual fun platformRumMonitor(): RumMonitor {
-    return RumMonitorAdapter(GlobalRumMonitor.get())
+    return RumMonitorAdapter(
+        GlobalRumMonitor.get(),
+        InternalRumSessionProviderListener
+    )
 }

--- a/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapter.kt
+++ b/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapter.kt
@@ -14,6 +14,7 @@ import com.datadog.kmp.rum.RumErrorSource
 import com.datadog.kmp.rum.RumMonitor
 import com.datadog.kmp.rum.RumResourceKind
 import com.datadog.kmp.rum.RumResourceMethod
+import com.datadog.kmp.rum.configuration.AdvancedRumSessionListener
 import com.datadog.kmp.rum.featureoperations.FailureReason
 import com.datadog.android.rum.ExperimentalRumApi as NativeExperimentalRumApi
 import com.datadog.android.rum.RumActionType as NativeRumActionType
@@ -23,8 +24,10 @@ import com.datadog.android.rum.RumResourceKind as NativeRumResourceKind
 import com.datadog.android.rum.RumResourceMethod as NativeRumResourceMethod
 import com.datadog.android.rum.featureoperations.FailureReason as NativeFailureReason
 
-internal class RumMonitorAdapter(private val nativeRumMonitor: NativeRumMonitor) :
-    RumMonitor,
+internal class RumMonitorAdapter(
+    private val nativeRumMonitor: NativeRumMonitor,
+    private val rumSessionListener: AdvancedRumSessionListener
+) : RumMonitor,
     AdvancedNetworkRumMonitor {
 
     // region RumMonitor
@@ -146,6 +149,7 @@ internal class RumMonitorAdapter(private val nativeRumMonitor: NativeRumMonitor)
 
     override fun stopSession() {
         nativeRumMonitor.stopSession()
+        rumSessionListener.onSessionStopped()
     }
 
     // endregion

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
@@ -5,6 +5,7 @@ import com.datadog.kmp.rum.RumActionType
 import com.datadog.kmp.rum.RumErrorSource
 import com.datadog.kmp.rum.RumResourceKind
 import com.datadog.kmp.rum.RumResourceMethod
+import com.datadog.kmp.rum.configuration.AdvancedRumSessionListener
 import com.datadog.kmp.rum.featureoperations.FailureReason
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.datadog.tools.unit.forge.aThrowable
@@ -47,11 +48,14 @@ class RumMonitorAdapterTest {
     @Mock
     lateinit var mockNativeRumMonitor: NativeRumMonitor
 
+    @Mock
+    internal lateinit var mockRumSessionListener: AdvancedRumSessionListener
+
     private lateinit var testedRumMonitorAdapter: RumMonitorAdapter
 
     @BeforeEach
     fun `set up`() {
-        testedRumMonitorAdapter = RumMonitorAdapter(mockNativeRumMonitor)
+        testedRumMonitorAdapter = RumMonitorAdapter(mockNativeRumMonitor, mockRumSessionListener)
     }
 
     @Test
@@ -421,6 +425,15 @@ class RumMonitorAdapterTest {
 
         // Then
         verify(mockNativeRumMonitor).stopSession()
+    }
+
+    @Test
+    fun `M call onSessionStopped W stopSession`() {
+        // When
+        testedRumMonitorAdapter.stopSession()
+
+        // Then
+        verify(mockRumSessionListener).onSessionStopped()
     }
 
     // region private

--- a/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/RumMonitor.kt
+++ b/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/RumMonitor.kt
@@ -7,6 +7,7 @@
 package com.datadog.kmp.rum
 
 import cocoapods.DatadogRUM.DDRUMMonitor
+import com.datadog.kmp.rum.configuration.InternalRumSessionProviderListener
 import com.datadog.kmp.rum.internal.DDRumMonitorProxy
 import com.datadog.kmp.rum.internal.RumMonitorAdapter
 import platform.Foundation.NSError
@@ -71,5 +72,8 @@ fun RumMonitor.addError(
 }
 
 internal actual fun platformRumMonitor(): RumMonitor {
-    return RumMonitorAdapter(DDRumMonitorProxy.create(DDRUMMonitor.shared()))
+    return RumMonitorAdapter(
+        DDRumMonitorProxy.create(DDRUMMonitor.shared()),
+        InternalRumSessionProviderListener
+    )
 }

--- a/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapter.kt
+++ b/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapter.kt
@@ -51,6 +51,7 @@ import com.datadog.kmp.rum.RumErrorSource
 import com.datadog.kmp.rum.RumMonitor
 import com.datadog.kmp.rum.RumResourceKind
 import com.datadog.kmp.rum.RumResourceMethod
+import com.datadog.kmp.rum.configuration.AdvancedRumSessionListener
 import com.datadog.kmp.rum.featureoperations.FailureReason
 import platform.Foundation.NSError
 import platform.Foundation.NSHTTPURLResponse
@@ -63,7 +64,8 @@ import platform.Foundation.numberWithLong
 import platform.UIKit.UIViewController
 
 internal class RumMonitorAdapter(
-    private val nativeRumMonitor: DDRumMonitorProxy
+    private val nativeRumMonitor: DDRumMonitorProxy,
+    private val rumSessionListener: AdvancedRumSessionListener
 ) : RumMonitor, AdvancedRumNetworkMonitor {
 
     // region RumMonitor
@@ -217,6 +219,7 @@ internal class RumMonitorAdapter(
 
     override fun stopSession() {
         nativeRumMonitor.stopSession()
+        rumSessionListener.onSessionStopped()
     }
 
     // endregion

--- a/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
+++ b/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
@@ -45,6 +45,7 @@ import com.datadog.kmp.rum.RumActionType
 import com.datadog.kmp.rum.RumErrorSource
 import com.datadog.kmp.rum.RumResourceKind
 import com.datadog.kmp.rum.RumResourceMethod
+import com.datadog.kmp.rum.configuration.AdvancedRumSessionListener
 import com.datadog.kmp.rum.featureoperations.FailureReason
 import com.datadog.tools.random.exhaustiveAttributes
 import com.datadog.tools.random.nullable
@@ -76,11 +77,13 @@ class RumMonitorAdapterTest {
 
     private val mockNativeRumMonitor = mock<DDRumMonitorProxy>()
 
+    private val mockRumSessionListener = mock<AdvancedRumSessionListener>()
+
     private lateinit var testedRumMonitorAdapter: RumMonitorAdapter
 
     @BeforeTest
     fun `set up`() {
-        testedRumMonitorAdapter = RumMonitorAdapter(mockNativeRumMonitor)
+        testedRumMonitorAdapter = RumMonitorAdapter(mockNativeRumMonitor, mockRumSessionListener)
     }
 
     // region RumMonitor
@@ -572,6 +575,15 @@ class RumMonitorAdapterTest {
 
         // Then
         verify { mockNativeRumMonitor.stopSession() }
+    }
+
+    @Test
+    fun `M call onSessionStopped W stopSession`() {
+        // When
+        testedRumMonitorAdapter.stopSession()
+
+        // Then
+        verify { mockRumSessionListener.onSessionStopped() }
     }
 
     // endregion

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
@@ -208,7 +208,7 @@ class RumConfiguration internal constructor(internal val nativeConfiguration: An
          * Builds a [RumConfiguration] based on the current state of this Builder.
          */
         fun build(): RumConfiguration {
-            val internalSessionListener = InternalRumSessionProvider
+            val internalSessionListener = InternalRumSessionProviderListener
             val combinedListener = CombinedRumSessionListener(internalSessionListener, userSessionListener)
 
             platformBuilder.setSessionListener(combinedListener)

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumSessionProvider.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumSessionProvider.kt
@@ -8,7 +8,11 @@ package com.datadog.kmp.rum.configuration
 
 import kotlin.concurrent.Volatile
 
-internal object InternalRumSessionProvider : RumSessionProvider, RumSessionListener {
+internal interface AdvancedRumSessionListener : RumSessionListener {
+    fun onSessionStopped()
+}
+
+internal object InternalRumSessionProviderListener : RumSessionProvider, AdvancedRumSessionListener {
 
     @Volatile
     override var sessionId: String? = null
@@ -21,6 +25,10 @@ internal object InternalRumSessionProvider : RumSessionProvider, RumSessionListe
             sessionId
         }
     }
+
+    override fun onSessionStopped() {
+        sessionId = null
+    }
 }
 
 interface RumSessionProvider {
@@ -31,6 +39,6 @@ interface RumSessionProvider {
         /**
          * This is internal API and shouldn't be used by the clients.
          */
-        fun get(): RumSessionProvider = InternalRumSessionProvider
+        fun get(): RumSessionProvider = InternalRumSessionProviderListener
     }
 }


### PR DESCRIPTION
### What does this PR do?

When `RumMonitor.stopSession` is called, `RumSessionListener.onSessionStarted` **is not** invoked, so this PR adds a hook for the `RumMonitor.stopSession` call to be able to erase current RUM session ID which is used for the Ktor instrumentation trace propagation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

