### PR TITLE
Revert update to Kotlin 2.1.21

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,11 +162,11 @@ sample-app-build-ios:
     - pod repo update
     - export DD_AGENT_PATH="$(pwd)/$DD_JAVA_AGENT_FILE"
     # by some reason without this line xcodebuild below fails
-    - ./gradlew :core:podBuildDatadogCoreIosSimulator
-      :core:podBuildDatadogCrashReportingIosSimulator
-      :features:rum:podBuildDatadogRUMIosSimulator
-      :features:logs:podBuildDatadogLogsIosSimulator
-      :features:session-replay:podBuildDatadogSessionReplayIosSimulator
+    - ./gradlew :core:podBuildDatadogCoreIphonesimulator
+      :core:podBuildDatadogCrashReportingIphonesimulator
+      :features:rum:podBuildDatadogRUMIphonesimulator
+      :features:logs:podBuildDatadogLogsIphonesimulator
+      :features:session-replay:podBuildDatadogSessionReplayIphonesimulator
       --no-daemon -Dorg.gradle.jvmargs=-javaagent:$DD_AGENT_PATH=$DD_COMMON_AGENT_CONFIG
     - xcodebuild -project sample/appleApp/appleApp.xcodeproj -destination "$BUILD_DESTINATION" -scheme "Sample iOS" build | xcbeautify --preserve-unbeautified
 
@@ -181,10 +181,10 @@ sample-app-build-tvos:
     - export DD_AGENT_PATH="$(pwd)/$DD_JAVA_AGENT_FILE"
     # temporary workaround for RUM-4282
     # by some reason without this line xcodebuild below fails
-    - ./gradlew :core:podBuildDatadogCoreTvosSimulator
-      :core:podBuildDatadogCrashReportingTvosSimulator
-      :features:rum:podBuildDatadogRUMTvosSimulator
-      :features:logs:podBuildDatadogLogsTvosSimulator
+    - ./gradlew :core:podBuildDatadogCoreAppletvsimulator
+      :core:podBuildDatadogCrashReportingAppletvsimulator
+      :features:rum:podBuildDatadogRUMAppletvsimulator
+      :features:logs:podBuildDatadogLogsAppletvsimulator
       --no-daemon -Dorg.gradle.jvmargs=-javaagent:$DD_AGENT_PATH=$DD_COMMON_AGENT_CONFIG
     - xcodebuild -project sample/appleApp/appleApp.xcodeproj -destination "$BUILD_DESTINATION" -scheme "Sample tvOS" build | xcbeautify --preserve-unbeautified
 

--- a/core/android-transitiveDependencies
+++ b/core/android-transitiveDependencies
@@ -5,7 +5,7 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    3 Mb

--- a/features/logs/android-transitiveDependencies
+++ b/features/logs/android-transitiveDependencies
@@ -2,7 +2,7 @@ Dependencies List
 
 com.datadoghq:dd-sdk-android-core:3.1.0                         :  755 Kb
 com.datadoghq:dd-sdk-android-logs:3.1.0                         :  151 Kb
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/features/logs/src/appleTest/kotlin/com/datadog/kmp/log/LoggerPlatformExtTest.kt
+++ b/features/logs/src/appleTest/kotlin/com/datadog/kmp/log/LoggerPlatformExtTest.kt
@@ -10,6 +10,7 @@ import com.datadog.kmp.log.internal.IOSPlatformLogger
 import dev.mokkery.mock
 import dev.mokkery.verify
 import platform.Foundation.NSError
+import kotlin.test.Ignore
 import kotlin.test.Test
 
 class LoggerPlatformExtTest {
@@ -18,6 +19,7 @@ class LoggerPlatformExtTest {
 
     private val testedLogger = Logger(mockPlatformLogger)
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call platform logger+debug W debug with NSError`() {
         // Given
@@ -34,6 +36,7 @@ class LoggerPlatformExtTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call platform logger+info W info with NSError`() {
         // Given
@@ -50,6 +53,7 @@ class LoggerPlatformExtTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call platform logger+warn W warn with NSError`() {
         // Given
@@ -66,6 +70,7 @@ class LoggerPlatformExtTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call platform logger+error W error with NSError`() {
         // Given
@@ -82,6 +87,7 @@ class LoggerPlatformExtTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call platform logger+critical W critical with NSError`() {
         // Given
@@ -98,6 +104,7 @@ class LoggerPlatformExtTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call platform logger+info W log+info with NSError`() {
         // Given

--- a/features/rum/android-transitiveDependencies
+++ b/features/rum/android-transitiveDependencies
@@ -24,7 +24,7 @@ androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
 androidx.viewpager:viewpager:1.0.0                              :   52 Kb
 com.datadoghq:dd-sdk-android-core:3.1.0                         :  755 Kb
 com.datadoghq:dd-sdk-android-rum:3.1.0                          :    2 Mb
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.1         : 1457 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
+++ b/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/internal/RumMonitorAdapterTest.kt
@@ -146,6 +146,7 @@ class RumMonitorAdapterTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call native startViewWithViewController W startView + ViewController key type `() {
         // Given
@@ -181,6 +182,7 @@ class RumMonitorAdapterTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call native stopViewWithViewController W stopView + ViewController key type`() {
         // Given
@@ -278,6 +280,7 @@ class RumMonitorAdapterTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call native stopResourceWithResourceKey W stopResource`() {
         // Given
@@ -302,7 +305,7 @@ class RumMonitorAdapterTest {
         }
     }
 
-    @Ignore // TODO RUM-11751 Segfault due to null status code, although Objective-C API allow it
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @OptIn(DelicateMokkeryApi::class)
     @Test
     fun `M call native stopResourceWithErrorWithResourceKey W stopResourceWithError + no status code`() {
@@ -335,6 +338,7 @@ class RumMonitorAdapterTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @OptIn(DelicateMokkeryApi::class)
     @Test
     fun `M call native stopResourceWithErrorWithResourceKey W stopResourceWithError + with status code`() {
@@ -365,11 +369,12 @@ class RumMonitorAdapterTest {
                 matches {
                     it is NSHTTPURLResponse && it.statusCode == fakeStatusCode.toLong()
                 },
-                (fakeAttributes + (INCLUDE_BINARY_IMAGES_KEY to true)).eraseKeyType()
+                fakeAttributes.eraseKeyType()
             )
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @OptIn(DelicateMokkeryApi::class)
     @Test
     fun `M call native addErrorWithError W addError + null throwable`() {
@@ -399,6 +404,7 @@ class RumMonitorAdapterTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @OptIn(DelicateMokkeryApi::class)
     @Test
     fun `M call native addErrorWithError W addError + with throwable`() {
@@ -424,7 +430,7 @@ class RumMonitorAdapterTest {
                         it.localizedDescription == "$fakeMessage\n${fakeThrowable.message}"
                 },
                 fakeErrorSource.native,
-                (fakeAttributes + (INCLUDE_BINARY_IMAGES_KEY to true)).eraseKeyType()
+                fakeAttributes.eraseKeyType()
             )
         }
     }
@@ -578,6 +584,7 @@ class RumMonitorAdapterTest {
 
     // region AdvanceRumNetworkMonitor
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call native addResourceMetricsWithResourceKey W addResourceMetrics`() {
         // Given
@@ -600,6 +607,7 @@ class RumMonitorAdapterTest {
 
     // endregion
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call native stopResourceWithResourceKey W stopResource + platform types`() {
         // Given
@@ -622,6 +630,7 @@ class RumMonitorAdapterTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call native stopResourceWithErrorWithResourceKey W stopResourceWithError + platform types + NSError`() {
         // Given
@@ -639,11 +648,12 @@ class RumMonitorAdapterTest {
                 fakeKey,
                 fakeError,
                 fakeResponse,
-                (fakeAttributes + (INCLUDE_BINARY_IMAGES_KEY to true)).eraseKeyType()
+                fakeAttributes.eraseKeyType()
             )
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call native stopResourceWithErrorWithResourceKey W stopResourceWithError + platform types + message`() {
         // Given
@@ -666,6 +676,7 @@ class RumMonitorAdapterTest {
         }
     }
 
+    @Ignore // TODO RUM-4961 Update to Kotlin 2.0.20 which supports KClass for Objective-C classes
     @Test
     fun `M call native addErrorWithError W addError + platform types`() {
         // Given
@@ -681,7 +692,7 @@ class RumMonitorAdapterTest {
             mockNativeRumMonitor.addErrorWithError(
                 fakeError,
                 fakeSource.native,
-                (fakeAttributes + (INCLUDE_BINARY_IMAGES_KEY to true)).eraseKeyType()
+                fakeAttributes.eraseKeyType()
             )
         }
     }
@@ -757,10 +768,6 @@ class RumMonitorAdapterTest {
                 FailureReason.ABANDONED -> DDRUMFeatureOperationFailureReasonAbandoned
             }
         }
-
-    private companion object {
-        const val INCLUDE_BINARY_IMAGES_KEY = "_dd.error.include_binary_images"
-    }
 
     // endregion
 }

--- a/features/session-replay/android-transitiveDependencies
+++ b/features/session-replay/android-transitiveDependencies
@@ -2,7 +2,7 @@ Dependencies List
 
 com.datadoghq:dd-sdk-android-core:3.1.0                         :  755 Kb
 com.datadoghq:dd-sdk-android-session-replay:3.1.0               :  784 Kb
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    3 Mb

--- a/features/webview/android-transitiveDependencies
+++ b/features/webview/android-transitiveDependencies
@@ -2,7 +2,7 @@ Dependencies List
 
 com.datadoghq:dd-sdk-android-core:3.1.0                         :  755 Kb
 com.datadoghq:dd-sdk-android-webview:3.1.0                      :   89 Kb
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.10.1"
-kotlin = "2.1.21"
+kotlin = "2.0.21"
 compose = "1.6.6"
 compose-material3 = "1.1.2"
 androidx-fragment = "1.5.1"
@@ -36,7 +36,7 @@ jUnitMockitoExt = "5.12.0"
 assertJ = "3.18.1"
 elmyr = "1.4.0"
 mockitoKotlin = "5.3.1"
-mokkery = "2.7.3"
+mokkery = "2.3.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/integrations/ktor/android-transitiveDependencies
+++ b/integrations/ktor/android-transitiveDependencies
@@ -11,7 +11,7 @@ io.ktor:ktor-websocket-serialization-jvm:2.3.13                 :    6 Kb
 io.ktor:ktor-websockets-jvm:2.3.13                              :  173 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22                  :  963 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22                  :  969 b 
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1         : 1512 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.1             :  953 b 
 org.jetbrains:annotations:23.0.0                                :   28 Kb

--- a/integrations/ktor/build.gradle.kts
+++ b/integrations/ktor/build.gradle.kts
@@ -5,6 +5,8 @@
  */
 
 import dev.mokkery.MockMode
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -64,6 +66,13 @@ kotlin {
         appleMain.dependencies {
             implementation(libs.kotlinx.datetime)
         }
+    }
+
+    // fix for w: KLIB resolver: The same 'unique_name=org.jetbrains.kotlinx:atomicfu' found in more than one library
+    // see https://youtrack.jetbrains.com/issue/KT-71206, should be fixed in Kotlin 2.1.0
+    targets.withType<KotlinNativeTargetWithSimulatorTests> {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        compilerOptions.allWarningsAsErrors = false
     }
 }
 

--- a/integrations/ktor3/android-transitiveDependencies
+++ b/integrations/ktor3/android-transitiveDependencies
@@ -10,7 +10,7 @@ io.ktor:ktor-sse-jvm:3.0.3                                      :    4 Kb
 io.ktor:ktor-utils-jvm:3.0.3                                    :  322 Kb
 io.ktor:ktor-websocket-serialization-jvm:3.0.3                  :    6 Kb
 io.ktor:ktor-websockets-jvm:3.0.3                               :  164 Kb
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.9.0         : 1429 Kb
 org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm:0.5.4           :   21 Kb
 org.jetbrains.kotlinx:kotlinx-io-core-jvm:0.5.4                 :  147 Kb

--- a/integrations/ktor3/build.gradle.kts
+++ b/integrations/ktor3/build.gradle.kts
@@ -5,6 +5,8 @@
  */
 
 import dev.mokkery.MockMode
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
 import java.nio.file.Paths
 
 plugins {
@@ -85,6 +87,13 @@ kotlin {
                 srcDirs(Paths.get("..", "ktor", "src", "androidMain").toFile())
             }
         }
+    }
+
+    // fix for w: KLIB resolver: The same 'unique_name=org.jetbrains.kotlinx:atomicfu' found in more than one library
+    // see https://youtrack.jetbrains.com/issue/KT-71206, should be fixed in Kotlin 2.1.0
+    targets.withType<KotlinNativeTargetWithSimulatorTests> {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        compilerOptions.allWarningsAsErrors = false
     }
 }
 

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
@@ -25,8 +25,7 @@ import com.datadog.kmp.rum.RumMonitor
 import com.datadog.kmp.rum.configuration.RumConfiguration
 import com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
 import com.datadog.kmp.rum.featureoperations.FailureReason
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
+import kotlin.random.Random
 
 const val HOME_SCREEN_NAME = "Home"
 const val LOGS_SCREEN_NAME = "Logs"
@@ -165,9 +164,9 @@ fun triggerUncheckedException() {
     throw RuntimeException(cause)
 }
 
-@OptIn(ExperimentalTime::class, ExperimentalRumApi::class)
+@OptIn(ExperimentalRumApi::class)
 fun startFeatureOperation() {
-    val operationKey = "$FEATURE_OPERATION_NAME/${Clock.System.now().toEpochMilliseconds()}"
+    val operationKey = "$FEATURE_OPERATION_NAME/${Random.nextInt()}"
     RumMonitor.get().startFeatureOperation(FEATURE_OPERATION_NAME, operationKey, extensiveAdditionalProperties)
     activeFeatureOperationKeys += operationKey
 }

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/config/DatadogBuildConfigExtension.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/config/DatadogBuildConfigExtension.kt
@@ -20,4 +20,4 @@ internal val DatadogBuildConfigExtension.jvmTargetOrDefault
     get() = jvmTarget.getOrElse(JvmTarget.JVM_17)
 
 internal val DatadogBuildConfigExtension.kotlinVersionOrDefault
-    get() = kotlinVersion.getOrElse(KotlinVersion.KOTLIN_2_1)
+    get() = kotlinVersion.getOrElse(KotlinVersion.KOTLIN_2_0)

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/generator/AndroidModelsMappingFileGenerator.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/generator/AndroidModelsMappingFileGenerator.kt
@@ -190,9 +190,6 @@ internal class AndroidModelsMappingFileGenerator(
         val receiver = ClassName.bestGuess("$androidModelsPackageName.$fullCommonEnumName")
         fileSpecBuilder.addFunction(
             FunSpec.builder(ENUM_CONVERSION_METHOD_NAME)
-                // needed, because the actual runtime dependency of Datadog Android SDK may be newer than used for
-                // build time, so new enum members may arise
-                .apply { addSuppressAnnotation("REDUNDANT_ELSE_IN_WHEN") }
                 .addModifiers(KModifier.INTERNAL, KModifier.INLINE)
                 .receiver(receiver)
                 .returns(returnClass)

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/generator/IOSModelsMappingFileGenerator.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/generator/IOSModelsMappingFileGenerator.kt
@@ -464,6 +464,17 @@ internal class IOSModelsMappingFileGenerator(
         }
     }
 
+    private fun FunSpec.Builder.addSuppressAnnotation(ruleName: String) {
+        val alreadyExists = annotations.any {
+            it.typeName.toString() == "kotlin.Suppress" && it.members.any {
+                it.toString().contains(ruleName)
+            }
+        }
+        if (alreadyExists) return
+
+        addAnnotation(AnnotationSpec.builder(Suppress::class).addMember("%S", ruleName).build())
+    }
+
     private val TypeProperty.asPropertyName
         get() = name.trimStart { it == '_' }.toCamelCaseAsVar()
 

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/generator/NativeModelsMappingFileGenerator.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/generator/NativeModelsMappingFileGenerator.kt
@@ -7,9 +7,7 @@
 package com.datadog.build.plugin.jsonschema.generator
 
 import com.datadog.build.plugin.jsonschema.TypeDefinition
-import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FunSpec
 
 abstract class NativeModelsMappingFileGenerator(
     packageName: String,
@@ -38,17 +36,6 @@ abstract class NativeModelsMappingFileGenerator(
         } else {
             name
         }
-    }
-
-    protected fun FunSpec.Builder.addSuppressAnnotation(ruleName: String) {
-        val alreadyExists = annotations.any {
-            it.typeName.toString() == "kotlin.Suppress" && it.members.any {
-                it.toString().contains(ruleName)
-            }
-        }
-        if (alreadyExists) return
-
-        addAnnotation(AnnotationSpec.builder(Suppress::class).addMember("%S", ruleName).build())
     }
 
     protected companion object {

--- a/tools/build-plugins/src/test/resources/AndroidViewEventMappingExt.kt
+++ b/tools/build-plugins/src/test/resources/AndroidViewEventMappingExt.kt
@@ -45,7 +45,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventSession.toC
   sampledForReplay = sampledForReplay,
 )
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventSessionType.toCommonEnum():
     ViewEvent.ViewEventSessionType = when(this) {
   com.datadog.android.rum.model.ViewEvent.ViewEventSessionType.USER ->
@@ -57,7 +56,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventSessionType
   else -> ViewEvent.ViewEventSessionType.USER
 }
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventSource.toCommonEnum():
     ViewEvent.ViewEventSource = when(this) {
   com.datadog.android.rum.model.ViewEvent.ViewEventSource.ANDROID ->
@@ -122,7 +120,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.ViewEventView.toComm
   jsRefreshRate = jsRefreshRate?.toCommonModel(),
 )
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.LoadingType.toCommonEnum():
     ViewEvent.LoadingType = when(this) {
   com.datadog.android.rum.model.ViewEvent.LoadingType.INITIAL_LOAD ->
@@ -213,7 +210,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.Connectivity.toCommo
   cellular = cellular?.toCommonModel(),
 )
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.Status.toCommonEnum(): ViewEvent.Status
     = when(this) {
   com.datadog.android.rum.model.ViewEvent.Status.CONNECTED -> ViewEvent.Status.CONNECTED
@@ -222,7 +218,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.Status.toCommonEnum(
   else -> ViewEvent.Status.CONNECTED
 }
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.EffectiveType.toCommonEnum():
     ViewEvent.EffectiveType = when(this) {
   com.datadog.android.rum.model.ViewEvent.EffectiveType.SLOW_2G -> ViewEvent.EffectiveType.SLOW_2G
@@ -287,7 +282,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.Device.toCommonModel
   architecture = architecture,
 )
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.DeviceType.toCommonEnum():
     ViewEvent.DeviceType = when(this) {
   com.datadog.android.rum.model.ViewEvent.DeviceType.MOBILE -> ViewEvent.DeviceType.MOBILE
@@ -317,7 +311,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.DdSession.toCommonMo
   sessionPrecondition = sessionPrecondition?.toCommonEnum(),
 )
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.Plan.toCommonEnum(): ViewEvent.Plan =
     when(this) {
   com.datadog.android.rum.model.ViewEvent.Plan.PLAN_1 -> ViewEvent.Plan.PLAN_1
@@ -325,7 +318,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.Plan.toCommonEnum():
   else -> ViewEvent.Plan.PLAN_1
 }
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.SessionPrecondition.toCommonEnum():
     ViewEvent.SessionPrecondition = when(this) {
   com.datadog.android.rum.model.ViewEvent.SessionPrecondition.USER_APP_LAUNCH ->
@@ -358,7 +350,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.PageState.toCommonMo
   start = start,
 )
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.State.toCommonEnum(): ViewEvent.State =
     when(this) {
   com.datadog.android.rum.model.ViewEvent.State.ACTIVE -> ViewEvent.State.ACTIVE
@@ -397,7 +388,6 @@ internal inline fun com.datadog.android.rum.model.ViewEvent.Privacy.toCommonMode
   replayLevel = replayLevel.toCommonEnum(),
 )
 
-@Suppress("REDUNDANT_ELSE_IN_WHEN")
 internal inline fun com.datadog.android.rum.model.ViewEvent.ReplayLevel.toCommonEnum():
     ViewEvent.ReplayLevel = when(this) {
   com.datadog.android.rum.model.ViewEvent.ReplayLevel.ALLOW -> ViewEvent.ReplayLevel.ALLOW


### PR DESCRIPTION
### What does this PR do?

This PR reverts https://github.com/DataDog/dd-sdk-kotlin-multiplatform/pull/209, because some customers are not able to update to Kotlin 2.1 yet, making it impossible to use the library.

Kotlin 2.1 introduced ABI bump (see full history [here](https://github.com/JetBrains/kotlin/blame/master/compiler/util-klib/KotlinAbiVersionBumpHistory.md)), so it is not possible to use KLIB files produced by it with Kotlin 2.0.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

