### PR TITLE
RUM-13870: Remove `kotlinx.datetime` usage

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ gson = "2.11.0"
 ktor2 = "2.3.13"
 ktor3 = "3.0.3"
 kotlinxCoroutines = "1.8.1"
-kotlinxDatetime = "0.6.0"
 uuid = "0.8.4"
 
 okHttp = "4.12.0"
@@ -78,8 +77,6 @@ okHttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okHttp" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-Test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
-
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 uuid = { module = "com.benasher44:uuid", version.ref = "uuid" }
 

--- a/integrations/ktor/build.gradle.kts
+++ b/integrations/ktor/build.gradle.kts
@@ -61,9 +61,6 @@ kotlin {
             implementation(libs.ktor2.client.mock)
             implementation(projects.tools.unit)
         }
-        appleMain.dependencies {
-            implementation(libs.kotlinx.datetime)
-        }
     }
 }
 

--- a/integrations/ktor/src/appleMain/kotlin/com/datadog/kmp/ktor/RandomExt.ios.kt
+++ b/integrations/ktor/src/appleMain/kotlin/com/datadog/kmp/ktor/RandomExt.ios.kt
@@ -6,7 +6,14 @@
 
 package com.datadog.kmp.ktor
 
-import kotlinx.datetime.Clock
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSCalendarUnitNanosecond
+import platform.Foundation.NSDate
 import kotlin.random.Random
 
-internal actual val RNG: Random = Random(Clock.System.now().nanosecondsOfSecond.toLong())
+internal actual val RNG: Random = Random(
+    NSCalendar.currentCalendar.component(
+        unit = NSCalendarUnitNanosecond,
+        fromDate = NSDate()
+    )
+)

--- a/integrations/ktor/src/appleMain/kotlin/com/datadog/kmp/ktor/internal/trace/DefaultTraceIdGenerator.kt
+++ b/integrations/ktor/src/appleMain/kotlin/com/datadog/kmp/ktor/internal/trace/DefaultTraceIdGenerator.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.kmp.ktor.internal.trace
 
-import kotlinx.datetime.Clock
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
 
-internal actual fun epochSeconds(): Long = Clock.System.now().epochSeconds
+internal actual fun epochSeconds(): Long = NSDate().timeIntervalSince1970.toLong()

--- a/integrations/ktor3/build.gradle.kts
+++ b/integrations/ktor3/build.gradle.kts
@@ -76,9 +76,6 @@ kotlin {
             kotlin {
                 srcDirs(Paths.get("..", "ktor", "src", "appleMain").toFile())
             }
-            dependencies {
-                implementation(libs.kotlinx.datetime)
-            }
         }
         androidMain {
             kotlin {


### PR DESCRIPTION
### What does this PR do?

Fixes #231. ABI in `kotlinx.datetime` is unstable and now it is proposed to use `kotlin.time` instead, but this API is experimental.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

