### PR TITLE
RUM-11522: Add `user.id` and `account.id` to the baggage header

### DIFF
--- a/core/api/commonMain/apiSurface
+++ b/core/api/commonMain/apiSurface
@@ -55,6 +55,11 @@ enum com.datadog.kmp.core.configuration.UploadFrequency
   - RARE
 fun interface com.datadog.kmp.event.EventMapper<T: Any>
   fun map(T): T?
+interface com.datadog.kmp.internal.DatadogContextProvider
+  val userId: String?
+  val accountId: String?
+  companion object 
+    fun get(): DatadogContextProvider
 object com.datadog.kmp.internal.InternalProxy
   val isCrashReportingEnabled: Boolean
 enum com.datadog.kmp.privacy.TrackingConsent

--- a/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -44,6 +44,14 @@ actual object Datadog {
     @Volatile
     internal actual var isCrashReportingEnabled: Boolean = false
 
+    // TODO RUM-0000 We should have a subscription for Datadog Context on Android, it will be
+    //  less error-prone due to concurrency
+    @Volatile
+    internal actual var currentUserId: String? = null
+
+    @Volatile
+    internal actual var currentAccountId: String? = null
+
     /**
      * Initializes an instance of the Datadog SDK.
      * @param context your application context (applicable only for Android)
@@ -98,6 +106,7 @@ actual object Datadog {
         extraInfo: Map<String, Any?>
     ) {
         DatadogAndroid.setUserInfo(id, name, email, extraInfo)
+        currentUserId = id
     }
 
     /**
@@ -128,6 +137,7 @@ actual object Datadog {
      * you need to stop the view first by using `RumMonitor.get().stopView()`
      */
     actual fun clearUserInfo() {
+        currentUserId = null
         DatadogAndroid.clearUserInfo()
     }
 
@@ -151,6 +161,7 @@ actual object Datadog {
         extraInfo: Map<String, Any?>
     ) {
         DatadogAndroid.setAccountInfo(id, name, extraInfo)
+        currentAccountId = id
     }
 
     /**
@@ -181,6 +192,7 @@ actual object Datadog {
      *
      */
     actual fun clearAccountInfo() {
+        currentAccountId = null
         DatadogAndroid.clearAccountInfo()
     }
 
@@ -188,6 +200,8 @@ actual object Datadog {
      * Clears all unsent data in all registered features.
      */
     actual fun clearAllData() {
+        currentUserId = null
+        currentAccountId = null
         DatadogAndroid.clearAllData()
     }
 
@@ -195,6 +209,8 @@ actual object Datadog {
      * Stop the initialized SDK instance.
      */
     actual fun stopInstance() {
+        currentUserId = null
+        currentAccountId = null
         DatadogAndroid.stopInstance()
     }
 }

--- a/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -18,6 +18,7 @@ import cocoapods.DatadogCore.DDCoreLoggerLevelDebug
 import cocoapods.DatadogCore.DDCoreLoggerLevelError
 import cocoapods.DatadogCore.DDCoreLoggerLevelNone
 import cocoapods.DatadogCore.DDCoreLoggerLevelWarn
+import cocoapods.DatadogCore.DDCrossPlatformExtension
 import cocoapods.DatadogCore.DDSite
 import cocoapods.DatadogCore.DDTrackingConsent
 import cocoapods.DatadogCore.DDUploadFrequency
@@ -56,6 +57,12 @@ actual object Datadog {
     @Volatile
     internal actual var isCrashReportingEnabled: Boolean = false
 
+    @Volatile
+    internal actual var currentUserId: String? = null
+
+    @Volatile
+    internal actual var currentAccountId: String? = null
+
     /**
      * Initializes an instance of the Datadog SDK.
      * @param context your application context (applicable only for Android)
@@ -75,6 +82,11 @@ actual object Datadog {
         if (configuration.coreConfig.trackCrashes) {
             DDCrashReporter.enable()
             isCrashReportingEnabled = true
+        }
+
+        DDCrossPlatformExtension.subscribeToSharedContext {
+            currentUserId = it?.userId()
+            currentAccountId = it?.accountId()
         }
     }
 
@@ -214,6 +226,7 @@ actual object Datadog {
      * Stop the initialized SDK instance.
      */
     actual fun stopInstance() {
+        DDCrossPlatformExtension.unsubscribeFromSharedContext()
         DatadogIOS.stopInstance()
     }
 }

--- a/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -27,6 +27,9 @@ expect object Datadog {
 
     internal var isCrashReportingEnabled: Boolean
 
+    internal var currentUserId: String?
+    internal var currentAccountId: String?
+
     /**
      * Initializes an instance of the Datadog SDK.
      * @param context your application context (applicable only for Android)

--- a/core/src/commonMain/kotlin/com/datadog/kmp/internal/DatadogContextProvider.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/internal/DatadogContextProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.internal
+
+import com.datadog.kmp.Datadog
+
+/**
+ * This is internal API and shouldn't be used by the clients.
+ */
+interface DatadogContextProvider {
+    val userId: String?
+    val accountId: String?
+
+    companion object {
+        fun get(): DatadogContextProvider = object : DatadogContextProvider {
+            override val userId: String?
+                get() = Datadog.currentUserId
+            override val accountId: String?
+                get() = Datadog.currentAccountId
+        }
+    }
+}

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.kmp.ktor
 
+import com.datadog.kmp.internal.DatadogContextProvider
 import com.datadog.kmp.ktor.internal.plugin.DatadogKtorPlugin
 import com.datadog.kmp.ktor.internal.plugin.buildClientPlugin
 import com.datadog.kmp.ktor.internal.sampling.DeterministicTraceSampler
@@ -40,6 +41,7 @@ fun datadogKtorPlugin(
     return DatadogKtorPlugin(
         RumMonitor.get(),
         RumSessionProvider.get(),
+        DatadogContextProvider.get(),
         tracedHosts,
         DeterministicTraceSampler(traceSampleRate),
         traceContextInjection,

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaderType.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaderType.kt
@@ -11,6 +11,7 @@ import com.datadog.kmp.ktor.internal.trace.SpanId
 import com.datadog.kmp.ktor.internal.trace.TraceId
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.headers
+import io.ktor.http.HeadersBuilder
 
 /**
  * Defines the list of tracing header types that can be injected into http requests.
@@ -49,73 +50,115 @@ enum class TracingHeaderType {
         sampledIn: Boolean,
         traceId: TraceId,
         spanId: SpanId,
-        rumSessionId: String?
+        rumSessionId: String?,
+        userId: String?,
+        accountId: String?
     ) {
         request.headers {
             when (this@TracingHeaderType) {
-                DATADOG -> {
-                    // remove pre-existing if any
-                    remove(DATADOG_TRACE_ID_KEY)
-                    remove(DATADOG_TAGS_KEY)
-                    remove(DATADOG_SPAN_ID_KEY)
-                    remove(DATADOG_SAMPLING_PRIORITY_KEY)
-                    remove(DATADOG_ORIGIN_KEY)
-                    if (sampledIn) {
-                        val mostSignificantTraceId = traceId.high.toString(HEX_RADIX)
-                        append(DATADOG_TRACE_ID_KEY, traceId.low.toString())
-                        append(DATADOG_TAGS_KEY, "$DATADOG_MOST_SIGNIFICANT_TRACE_ID_TAG=$mostSignificantTraceId")
-                        append(DATADOG_SPAN_ID_KEY, spanId.raw.toString())
-                        append(DATADOG_SAMPLING_PRIORITY_KEY, DATADOG_KEEP_SAMPLING_DECISION)
-                        append(DATADOG_ORIGIN_KEY, DATADOG_ORIGIN_RUM)
-                    } else {
-                        append(DATADOG_SAMPLING_PRIORITY_KEY, DATADOG_DROP_SAMPLING_DECISION)
-                    }
-
-                    if (rumSessionId != null) {
-                        // even if it is Datadog headers, we re-use W3C header here
-                        addToW3cBaggage(DATADOG_RUM_SESSION_ID_TAG, rumSessionId)
-                    }
-                }
-
-                B3 -> {
-                    // remove pre-existing if any
-                    remove(B3_HEADER_KEY)
-                    if (sampledIn) {
-                        append(B3_HEADER_KEY, "${traceId.toHexString()}-${spanId.toHexString()}-1")
-                    } else {
-                        append(B3_HEADER_KEY, B3_DROP_SAMPLING_DECISION)
-                    }
-                }
-
-                B3MULTI -> {
-                    // remove pre-existing if any
-                    remove(B3M_TRACE_ID_KEY)
-                    remove(B3M_SPAN_ID_KEY)
-                    remove(B3M_SAMPLING_PRIORITY_KEY)
-                    if (sampledIn) {
-                        append(B3M_TRACE_ID_KEY, traceId.toHexString())
-                        append(B3M_SPAN_ID_KEY, spanId.toHexString())
-                        append(B3M_SAMPLING_PRIORITY_KEY, B3M_KEEP_SAMPLING_DECISION)
-                    } else {
-                        append(B3M_SAMPLING_PRIORITY_KEY, B3M_DROP_SAMPLING_DECISION)
-                    }
-                }
-
-                TRACECONTEXT -> {
-                    // remove pre-existing if any
-                    remove(W3C_TRACEPARENT_KEY)
-                    remove(W3C_TRACESTATE_KEY)
-
-                    val paddedTraceId = traceId.toHexString().padStart(W3C_TRACE_ID_LENGTH, '0')
-                    val paddedSpanId = spanId.toHexString().padStart(W3C_PARENT_ID_LENGTH, '0')
-                    val decision = if (sampledIn) W3C_SAMPLE_PRIORITY_ACCEPT else W3C_SAMPLE_PRIORITY_DROP
-                    append(W3C_TRACEPARENT_KEY, "00-$paddedTraceId-$paddedSpanId-$decision")
-
-                    if (rumSessionId != null) {
-                        addToW3cBaggage(DATADOG_RUM_SESSION_ID_TAG, rumSessionId)
-                    }
-                }
+                DATADOG -> injectDatadogHeaders(sampledIn, traceId, spanId, rumSessionId, userId, accountId)
+                B3 -> injectB3Headers(sampledIn, traceId, spanId)
+                B3MULTI -> injectB3MultiHeaders(sampledIn, traceId, spanId)
+                TRACECONTEXT -> injectTraceContextHeaders(sampledIn, traceId, spanId, rumSessionId, userId, accountId)
             }
+        }
+    }
+
+    private fun HeadersBuilder.injectDatadogHeaders(
+        sampledIn: Boolean,
+        traceId: TraceId,
+        spanId: SpanId,
+        rumSessionId: String?,
+        userId: String?,
+        accountId: String?
+    ) {
+        // remove pre-existing if any
+        remove(DATADOG_TRACE_ID_KEY)
+        remove(DATADOG_TAGS_KEY)
+        remove(DATADOG_SPAN_ID_KEY)
+        remove(DATADOG_SAMPLING_PRIORITY_KEY)
+        remove(DATADOG_ORIGIN_KEY)
+        if (sampledIn) {
+            val mostSignificantTraceId = traceId.high.toString(HEX_RADIX)
+            append(DATADOG_TRACE_ID_KEY, traceId.low.toString())
+            append(DATADOG_TAGS_KEY, "$DATADOG_MOST_SIGNIFICANT_TRACE_ID_TAG=$mostSignificantTraceId")
+            append(DATADOG_SPAN_ID_KEY, spanId.raw.toString())
+            append(DATADOG_SAMPLING_PRIORITY_KEY, DATADOG_KEEP_SAMPLING_DECISION)
+            append(DATADOG_ORIGIN_KEY, DATADOG_ORIGIN_RUM)
+        } else {
+            append(DATADOG_SAMPLING_PRIORITY_KEY, DATADOG_DROP_SAMPLING_DECISION)
+        }
+
+        if (rumSessionId != null) {
+            // even if it is Datadog headers, we re-use W3C header here
+            addToW3cBaggage(DATADOG_RUM_SESSION_ID_TAG, rumSessionId)
+        }
+        if (userId != null) {
+            addToW3cBaggage(DATADOG_USER_ID_TAG, userId)
+        }
+        if (accountId != null) {
+            addToW3cBaggage(DATADOG_ACCOUNT_ID_TAG, accountId)
+        }
+    }
+
+    private fun HeadersBuilder.injectTraceContextHeaders(
+        sampledIn: Boolean,
+        traceId: TraceId,
+        spanId: SpanId,
+        rumSessionId: String?,
+        userId: String?,
+        accountId: String?
+    ) {
+        // remove pre-existing if any
+        remove(W3C_TRACEPARENT_KEY)
+        remove(W3C_TRACESTATE_KEY)
+
+        val paddedTraceId = traceId.toHexString().padStart(W3C_TRACE_ID_LENGTH, '0')
+        val paddedSpanId = spanId.toHexString().padStart(W3C_PARENT_ID_LENGTH, '0')
+        val decision = if (sampledIn) W3C_SAMPLE_PRIORITY_ACCEPT else W3C_SAMPLE_PRIORITY_DROP
+        append(W3C_TRACEPARENT_KEY, "00-$paddedTraceId-$paddedSpanId-$decision")
+
+        if (rumSessionId != null) {
+            addToW3cBaggage(DATADOG_RUM_SESSION_ID_TAG, rumSessionId)
+        }
+
+        if (userId != null) {
+            addToW3cBaggage(DATADOG_USER_ID_TAG, userId)
+        }
+        if (accountId != null) {
+            addToW3cBaggage(DATADOG_ACCOUNT_ID_TAG, accountId)
+        }
+    }
+
+    private fun HeadersBuilder.injectB3Headers(
+        sampledIn: Boolean,
+        traceId: TraceId,
+        spanId: SpanId
+    ) {
+        // remove pre-existing if any
+        remove(B3_HEADER_KEY)
+        if (sampledIn) {
+            append(B3_HEADER_KEY, "${traceId.toHexString()}-${spanId.toHexString()}-1")
+        } else {
+            append(B3_HEADER_KEY, B3_DROP_SAMPLING_DECISION)
+        }
+    }
+
+    private fun HeadersBuilder.injectB3MultiHeaders(
+        sampledIn: Boolean,
+        traceId: TraceId,
+        spanId: SpanId
+    ) {
+        // remove pre-existing if any
+        remove(B3M_TRACE_ID_KEY)
+        remove(B3M_SPAN_ID_KEY)
+        remove(B3M_SAMPLING_PRIORITY_KEY)
+        if (sampledIn) {
+            append(B3M_TRACE_ID_KEY, traceId.toHexString())
+            append(B3M_SPAN_ID_KEY, spanId.toHexString())
+            append(B3M_SAMPLING_PRIORITY_KEY, B3M_KEEP_SAMPLING_DECISION)
+        } else {
+            append(B3M_SAMPLING_PRIORITY_KEY, B3M_DROP_SAMPLING_DECISION)
         }
     }
 }

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaders.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaders.kt
@@ -17,6 +17,8 @@ internal const val DATADOG_ORIGIN_KEY = "x-datadog-origin"
 internal const val DATADOG_ORIGIN_RUM = "rum"
 internal const val DATADOG_MOST_SIGNIFICANT_TRACE_ID_TAG = "_dd.p.tid"
 internal const val DATADOG_RUM_SESSION_ID_TAG = "session.id"
+internal const val DATADOG_USER_ID_TAG = "user.id"
+internal const val DATADOG_ACCOUNT_ID_TAG = "account.id"
 
 // taken from B3HttpCodec
 internal const val B3_HEADER_KEY = "b3"

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/HeadersExt.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/HeadersExt.kt
@@ -27,18 +27,17 @@ internal fun HeadersBuilder.w3cBaggage(): List<List<BaggageItem>>? {
     return existingHeaders
         .map {
             it.split(",")
-                // note: very simple parsing, without edge-cases, may be not 100% compliant with the spec
-                // it doesn't handle non-ASCII character encoding, because we are not going to read/modify such
-                // anyway in our flow
                 .filter { it.contains("=") }
                 .map {
                     val keyValueDelimiterIndex = it.indexOf('=')
                     val key = it.substring(0, keyValueDelimiterIndex).trim()
                     val value = it.substring(keyValueDelimiterIndex + 1).trim()
                     val metaIndex = value.indexOf(";")
+                    // don't decode existing items, we assume they are coming from elsewhere
+                    // we will encode values added by addToW3cBaggage below
                     if (metaIndex != -1) {
                         val metadata = value.substring(metaIndex + 1).trim()
-                        BaggageItem(key, value.substring(0, metaIndex), metadata)
+                        BaggageItem(key, value.take(metaIndex), metadata)
                     } else {
                         BaggageItem(key, value)
                     }
@@ -48,8 +47,8 @@ internal fun HeadersBuilder.w3cBaggage(): List<List<BaggageItem>>? {
 
 internal fun HeadersBuilder.addToW3cBaggage(key: String, value: String) {
     val existingBaggage = w3cBaggage()
-    if (existingBaggage == null) {
-        append(W3C_BAGGAGE_KEY, "$key=$value")
+    if (existingBaggage == null || existingBaggage.isEmpty()) {
+        append(W3C_BAGGAGE_KEY, "$key=${encodeBaggageValue(value)}")
     } else {
         remove(W3C_BAGGAGE_KEY)
         // https://www.w3.org/TR/baggage/#baggage-string
@@ -57,24 +56,63 @@ internal fun HeadersBuilder.addToW3cBaggage(key: String, value: String) {
         // >> The order of duplicate entries SHOULD be preserved when mutating the list. Producers SHOULD try
         // >> to produce a baggage-string without any list-members which duplicate the key of another list member.
         val headersWithGivenKey =
-            existingBaggage.filter { it.any { it.key == key } }
+            existingBaggage.filter { baggage -> baggage.any { it.key == key } }
         val updatedBaggage = if (headersWithGivenKey.isNotEmpty()) {
-            existingBaggage.map {
-                it.map {
-                    if (it.key == key) it.copy(value = value, metadata = null) else it
+            // we will deduplicate keys during the update
+            var keyUpdated = false
+            existingBaggage.map { baggage ->
+                baggage.mapNotNull {
+                    if (it.key == key) {
+                        if (keyUpdated) {
+                            null
+                        } else {
+                            keyUpdated = true
+                            it.copy(
+                                value = encodeBaggageValue(value),
+                                metadata = null
+                            )
+                        }
+                    } else {
+                        it
+                    }
                 }
             }
         } else {
             existingBaggage.toMutableList().apply {
-                add(removeLastOrNull().orEmpty().toMutableList().apply { add(BaggageItem(key, value)) })
+                add(
+                    removeLastOrNull().orEmpty().toMutableList()
+                        .apply { add(BaggageItem(key, encodeBaggageValue(value))) }
+                )
             }
         }
         updatedBaggage
+            .filter { it.isNotEmpty() }
             .forEach {
                 append(
                     W3C_BAGGAGE_KEY,
                     it.joinToString(separator = ",") { it.toHeaderString() }
                 )
             }
+    }
+}
+
+/**
+ * %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+ * ; US-ASCII characters excluding CTLs,
+ * ; whitespace, DQUOTE, comma, semicolon,
+ * ; and backslash
+ */
+private val ALLOWED_BAGGAGE_VALUE_CHARS =
+    setOf('!') + ('#'..'+') + ('-'..':') + ('<'..'[') + (']'..'~')
+
+@Suppress("MagicNumber")
+private fun encodeBaggageValue(value: String): String {
+    return value.encodeToByteArray().joinToString("") { byte ->
+        val char = byte.toInt().toChar()
+        if (char in ALLOWED_BAGGAGE_VALUE_CHARS) {
+            char.toString()
+        } else {
+            "%" + byte.toUByte().toString(16).uppercase().padStart(2, '0')
+        }
     }
 }

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
@@ -7,6 +7,7 @@
 package com.datadog.kmp.ktor.internal.plugin
 
 import com.benasher44.uuid.uuid4
+import com.datadog.kmp.internal.DatadogContextProvider
 import com.datadog.kmp.ktor.HttpRequestSnapshot
 import com.datadog.kmp.ktor.RUM_RULE_PSR
 import com.datadog.kmp.ktor.RUM_SPAN_ID
@@ -36,6 +37,7 @@ import io.ktor.util.AttributeKey
 internal class DatadogKtorPlugin(
     private val rumMonitor: RumMonitor,
     private val rumSessionProvider: RumSessionProvider,
+    private val datadogContextProvider: DatadogContextProvider,
     private val tracedHosts: Map<String, Set<TracingHeaderType>>,
     private val traceSampler: Sampler<TraceId>,
     private val traceContextInjection: TraceContextInjection,
@@ -59,7 +61,15 @@ internal class DatadogKtorPlugin(
 
         if (isSampledIn && traceHeaderTypes.isNotEmpty()) {
             traceHeaderTypes.forEach { headerType ->
-                headerType.injectHeaders(request, true, traceId, spanId, rumSessionProvider.sessionId)
+                headerType.injectHeaders(
+                    request,
+                    true,
+                    traceId,
+                    spanId,
+                    rumSessionProvider.sessionId,
+                    datadogContextProvider.userId,
+                    datadogContextProvider.accountId
+                )
             }
             request.attributes.put(DD_TRACE_ID_ATTR, traceId)
             request.attributes.put(DD_SPAN_ID_ATTR, spanId)
@@ -67,7 +77,15 @@ internal class DatadogKtorPlugin(
         } else {
             if (traceContextInjection == TraceContextInjection.All) {
                 traceHeaderTypes.forEach { headerType ->
-                    headerType.injectHeaders(request, false, traceId, spanId, rumSessionProvider.sessionId)
+                    headerType.injectHeaders(
+                        request,
+                        false,
+                        traceId,
+                        spanId,
+                        rumSessionProvider.sessionId,
+                        datadogContextProvider.userId,
+                        datadogContextProvider.accountId
+                    )
                 }
             }
         }

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/TracingHeaderTypeTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/TracingHeaderTypeTest.kt
@@ -17,43 +17,68 @@ import kotlin.test.assertEquals
 class TracingHeaderTypeTest {
 
     private var fakeRumSessionId = nullable(uuid4().toString())
+    private var fakeUserId = nullable(uuid4().toString())
+    private var fakeAccountId = nullable(uuid4().toString())
 
     @Test
     fun `M inject Datadog headers W injectHeaders`() {
         // Given
         val expectedHeaders = mapOf(
-            Fixture(TraceId(0u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(0u, 1337u),
+                SpanId(42u),
+                true,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("x-datadog-parent-id", "42")
                 put("x-datadog-trace-id", "1337")
                 put("x-datadog-tags", "_dd.p.tid=0")
                 put("x-datadog-sampling-priority", "1")
                 put("x-datadog-origin", "rum")
-                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+                putBaggage()
             },
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(1234567890u, 1337u),
+                SpanId(42u),
+                true,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("x-datadog-parent-id", "42")
                 put("x-datadog-trace-id", "1337")
                 put("x-datadog-tags", "_dd.p.tid=499602d2")
                 put("x-datadog-sampling-priority", "1")
                 put("x-datadog-origin", "rum")
-                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+                putBaggage()
             },
             Fixture(
                 TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
                 SpanId(ULong.MAX_VALUE),
                 true,
-                fakeRumSessionId
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
             ) to buildMap {
                 put("x-datadog-parent-id", "18446744073709551615")
                 put("x-datadog-trace-id", "18446744073709551615")
                 put("x-datadog-tags", "_dd.p.tid=ffffffffffffffff")
                 put("x-datadog-sampling-priority", "1")
                 put("x-datadog-origin", "rum")
-                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+                putBaggage()
             },
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(1234567890u, 1337u),
+                SpanId(42u),
+                false,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("x-datadog-sampling-priority", "0")
-                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+                putBaggage()
             }
         )
 
@@ -65,7 +90,9 @@ class TracingHeaderTypeTest {
                 it.key.sampledIn,
                 it.key.traceId,
                 it.key.spanId,
-                it.key.rumSessionId
+                it.key.rumSessionId,
+                it.key.userId,
+                it.key.accountId
             )
             val headers = fakeRequestBuilder.headers.entries()
                 .associate {
@@ -80,26 +107,49 @@ class TracingHeaderTypeTest {
     fun `M inject TraceContext headers W injectHeaders`() {
         // Given
         val expectedHeaders = mapOf(
-            Fixture(TraceId(0u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(0u, 1337u),
+                SpanId(42u),
+                true,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("traceparent", "00-00000000000000000000000000000539-000000000000002a-01")
-                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+                putBaggage()
             },
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(1234567890u, 1337u),
+                SpanId(42u),
+                true,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("traceparent", "00-00000000499602d20000000000000539-000000000000002a-01")
-                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+                putBaggage()
             },
             Fixture(
                 TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
                 SpanId(ULong.MAX_VALUE),
                 true,
-                fakeRumSessionId
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
             ) to buildMap {
                 put("traceparent", "00-ffffffffffffffffffffffffffffffff-ffffffffffffffff-01")
-                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+                putBaggage()
             },
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(1234567890u, 1337u),
+                SpanId(42u),
+                false,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("traceparent", "00-00000000499602d20000000000000539-000000000000002a-00")
-                if (fakeRumSessionId != null) put("baggage", "session.id=$fakeRumSessionId")
+                putBaggage()
             }
         )
 
@@ -111,7 +161,9 @@ class TracingHeaderTypeTest {
                 it.key.sampledIn,
                 it.key.traceId,
                 it.key.spanId,
-                it.key.rumSessionId
+                it.key.rumSessionId,
+                it.key.userId,
+                it.key.accountId
             )
             val headers = fakeRequestBuilder.headers.entries()
                 .associate {
@@ -126,21 +178,44 @@ class TracingHeaderTypeTest {
     fun `M inject B3 headers W injectHeaders`() {
         // Given
         val expectedHeaders = mapOf(
-            Fixture(TraceId(0u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(0u, 1337u),
+                SpanId(42u),
+                true,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("b3", "539-2a-1")
             },
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(1234567890u, 1337u),
+                SpanId(42u),
+                true,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("b3", "499602d20000000000000539-2a-1")
             },
             Fixture(
                 TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
                 SpanId(ULong.MAX_VALUE),
                 true,
-                fakeRumSessionId
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
             ) to buildMap {
                 put("b3", "ffffffffffffffffffffffffffffffff-ffffffffffffffff-1")
             },
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(1234567890u, 1337u),
+                SpanId(42u),
+                false,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("b3", "0")
             }
         )
@@ -153,7 +228,9 @@ class TracingHeaderTypeTest {
                 it.key.sampledIn,
                 it.key.traceId,
                 it.key.spanId,
-                it.key.rumSessionId
+                it.key.rumSessionId,
+                it.key.userId,
+                it.key.accountId
             )
             val headers = fakeRequestBuilder.headers.entries()
                 .associate {
@@ -168,12 +245,26 @@ class TracingHeaderTypeTest {
     fun `M inject B3Multi headers W injectHeaders`() {
         // Given
         val expectedHeaders = mapOf(
-            Fixture(TraceId(0u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(0u, 1337u),
+                SpanId(42u),
+                true,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("X-B3-TraceId", "539")
                 put("X-B3-SpanId", "2a")
                 put("X-B3-Sampled", "1")
             },
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), true, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(1234567890u, 1337u),
+                SpanId(42u),
+                true,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("X-B3-TraceId", "499602d20000000000000539")
                 put("X-B3-SpanId", "2a")
                 put("X-B3-Sampled", "1")
@@ -182,13 +273,22 @@ class TracingHeaderTypeTest {
                 TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
                 SpanId(ULong.MAX_VALUE),
                 true,
-                fakeRumSessionId
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
             ) to buildMap {
                 put("X-B3-TraceId", "ffffffffffffffffffffffffffffffff")
                 put("X-B3-SpanId", "ffffffffffffffff")
                 put("X-B3-Sampled", "1")
             },
-            Fixture(TraceId(1234567890u, 1337u), SpanId(42u), false, fakeRumSessionId) to buildMap {
+            Fixture(
+                TraceId(1234567890u, 1337u),
+                SpanId(42u),
+                false,
+                fakeRumSessionId,
+                fakeUserId,
+                fakeAccountId
+            ) to buildMap {
                 put("X-B3-Sampled", "0")
             }
         )
@@ -201,7 +301,9 @@ class TracingHeaderTypeTest {
                 it.key.sampledIn,
                 it.key.traceId,
                 it.key.spanId,
-                it.key.rumSessionId
+                it.key.rumSessionId,
+                it.key.userId,
+                it.key.accountId
             )
             val headers = fakeRequestBuilder.headers.entries()
                 .associate {
@@ -218,8 +320,24 @@ class TracingHeaderTypeTest {
         val traceId: TraceId,
         val spanId: SpanId,
         val sampledIn: Boolean,
-        val rumSessionId: String? = null
+        val rumSessionId: String? = null,
+        val userId: String? = null,
+        val accountId: String? = null
     )
+
+    private fun MutableMap<String, String>.putBaggage() {
+        val baggage = listOf(fakeRumSessionId, fakeUserId, fakeAccountId)
+        if (baggage.any { it != null }) {
+            put(
+                "baggage",
+                buildList {
+                    if (fakeRumSessionId != null) add("session.id=$fakeRumSessionId")
+                    if (fakeUserId != null) add("user.id=$fakeUserId")
+                    if (fakeAccountId != null) add("account.id=$fakeAccountId")
+                }.joinToString(",")
+            )
+        }
+    }
 
     // endregion
 }

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/HeadersExtTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/HeadersExtTest.kt
@@ -131,4 +131,22 @@ class HeadersExtTest {
             baggageHeaders.last()
         )
     }
+
+    @Test
+    fun `M encode only value added W addToW3cBaggage`() {
+        // Given
+        val headers = HeadersBuilder().apply {
+            // this one should be originally encoded, but let's assume that we have this header coming from
+            // elsewhere and encoding wasn't done
+            append("baggage", "user=Amélie")
+        }
+
+        // When
+        headers.addToW3cBaggage("user.id", "example user id")
+        headers.addToW3cBaggage("session.id", "abc-def")
+
+        // Then
+        val expected = "user=Amélie,user.id=example%20user%20id,session.id=abc-def"
+        assertEquals(expected, headers["baggage"])
+    }
 }

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.kmp.ktor.internal.plugin
 
 import com.benasher44.uuid.uuid4
+import com.datadog.kmp.internal.DatadogContextProvider
 import com.datadog.kmp.ktor.HEX_RADIX
 import com.datadog.kmp.ktor.RUM_RULE_PSR
 import com.datadog.kmp.ktor.RUM_SPAN_ID
@@ -84,12 +85,15 @@ class DatadogKtorPluginTest {
     private val mockSpanIdGenerator = mock<SpanIdGenerator>()
     private val mockRumResourceAttributesProvider = mock<RumResourceAttributesProvider>()
     private val mockRumSessionProvider = mock<RumSessionProvider>()
+    private val mockDatadogContextProvider = mock<DatadogContextProvider>()
 
     private val fakeRumRequestAttributes = exhaustiveAttributes()
     private val fakeRumResponseAttributes = exhaustiveAttributes()
     private val fakeRumErrorAttributes = exhaustiveAttributes()
 
     private var fakeRumSessionId = nullable(uuid4().toString())
+    private var fakeUserId = nullable(uuid4().toString())
+    private var fakeAccountId = nullable(uuid4().toString())
 
     private var testedPlugin = DatadogKtorPlugin(
         rumMonitor = mockRumMonitor,
@@ -99,7 +103,8 @@ class DatadogKtorPluginTest {
         traceIdGenerator = mockTraceIdGenerator,
         spanIdGenerator = mockSpanIdGenerator,
         rumSessionProvider = mockRumSessionProvider,
-        rumResourceAttributesProvider = mockRumResourceAttributesProvider
+        rumResourceAttributesProvider = mockRumResourceAttributesProvider,
+        datadogContextProvider = mockDatadogContextProvider
     )
 
     private val mockRequestHandler = mock<MockRequestHandler>()
@@ -127,6 +132,8 @@ class DatadogKtorPluginTest {
         }
         every { mockSpanIdGenerator.generateSpanId() } returnsBy { SpanId(randomULong()) }
         every { mockRumSessionProvider.sessionId } returnsBy { fakeRumSessionId }
+        every { mockDatadogContextProvider.userId } returnsBy { fakeUserId }
+        every { mockDatadogContextProvider.accountId } returnsBy { fakeAccountId }
         with(mockRumResourceAttributesProvider) {
             every { onRequest(any()) } returns fakeRumRequestAttributes
             every { onResponse(any()) } returns fakeRumResponseAttributes
@@ -393,13 +400,19 @@ class DatadogKtorPluginTest {
         assertThat(capturedRequestHeaders.first())
             .run {
                 val rumSessionId = fakeRumSessionId
-                val shouldInjectRumSessionId = with(fakeTracingHeaderTypes) {
+                val userId = fakeUserId
+                val accountId = fakeAccountId
+                val shouldInjectExtraBaggage = with(fakeTracingHeaderTypes) {
                     contains(TracingHeaderType.DATADOG) || contains(TracingHeaderType.TRACECONTEXT)
                 }
-                if (shouldInjectRumSessionId) {
+                if (shouldInjectExtraBaggage) {
                     if (rumSessionId == null) hasNoRumSessionId() else hasRumSessionId(rumSessionId)
+                    if (userId == null) hasNoUserId() else hasUserId(userId)
+                    if (accountId == null) hasNoAccountId() else hasAccountId(accountId)
                 } else {
                     hasNoRumSessionId()
+                    hasNoUserId()
+                    hasNoAccountId()
                 }
             }
 
@@ -470,13 +483,19 @@ class DatadogKtorPluginTest {
                     hasSamplingDecision(0, it)
                 }
                 val rumSessionId = fakeRumSessionId
-                val shouldInjectRumSessionId = with(fakeTracingHeaderTypes) {
+                val userId = fakeUserId
+                val accountId = fakeAccountId
+                val shouldInjectExtraBaggage = with(fakeTracingHeaderTypes) {
                     contains(TracingHeaderType.DATADOG) || contains(TracingHeaderType.TRACECONTEXT)
                 }
-                if (shouldInjectRumSessionId) {
+                if (shouldInjectExtraBaggage) {
                     if (rumSessionId == null) hasNoRumSessionId() else hasRumSessionId(rumSessionId)
+                    if (userId == null) hasNoUserId() else hasUserId(userId)
+                    if (accountId == null) hasNoAccountId() else hasAccountId(accountId)
                 } else {
                     hasNoRumSessionId()
+                    hasNoUserId()
+                    hasNoAccountId()
                 }
             }
     }
@@ -582,13 +601,19 @@ class DatadogKtorPluginTest {
                         hasSamplingDecision(0, it)
                     }
                     val rumSessionId = fakeRumSessionId
-                    val shouldInjectRumSessionId = with(fakeTracingHeaderTypes) {
+                    val userId = fakeUserId
+                    val accountId = fakeAccountId
+                    val shouldInjectExtraBaggage = with(fakeTracingHeaderTypes) {
                         contains(TracingHeaderType.DATADOG) || contains(TracingHeaderType.TRACECONTEXT)
                     }
-                    if (shouldInjectRumSessionId) {
+                    if (shouldInjectExtraBaggage) {
                         if (rumSessionId == null) hasNoRumSessionId() else hasRumSessionId(rumSessionId)
+                        if (userId == null) hasNoUserId() else hasUserId(userId)
+                        if (accountId == null) hasNoAccountId() else hasAccountId(accountId)
                     } else {
                         hasNoRumSessionId()
+                        hasNoUserId()
+                        hasNoAccountId()
                     }
                 }
         }
@@ -757,7 +782,7 @@ class DatadogKtorPluginTest {
             )
 
             mockRumMonitor.stopResourceWithError(
-                key = checkNotNull(capturedRequestId),
+                key = capturedRequestId,
                 statusCode = null,
                 message = "Ktor request error $fakeMethod $fakeUrl",
                 throwable = fakeThrowable,
@@ -838,7 +863,7 @@ class DatadogKtorPluginTest {
             )
 
             mockRumMonitor.stopResourceWithError(
-                key = checkNotNull(capturedRedirectRequestId),
+                key = capturedRedirectRequestId,
                 statusCode = null,
                 message = "Ktor request error $fakeMethod $fakeUrl/redirected",
                 throwable = fakeThrowable,
@@ -860,7 +885,8 @@ class DatadogKtorPluginTest {
             traceIdGenerator = mockTraceIdGenerator,
             spanIdGenerator = mockSpanIdGenerator,
             rumSessionProvider = mockRumSessionProvider,
-            rumResourceAttributesProvider = mockRumResourceAttributesProvider
+            rumResourceAttributesProvider = mockRumResourceAttributesProvider,
+            datadogContextProvider = mockDatadogContextProvider
         )
         val fakeClient = HttpClient(mockEngine) {
             install(testedPlugin.buildClientPlugin())
@@ -917,7 +943,8 @@ class DatadogKtorPluginTest {
             traceIdGenerator = mockTraceIdGenerator,
             spanIdGenerator = mockSpanIdGenerator,
             rumSessionProvider = mockRumSessionProvider,
-            rumResourceAttributesProvider = mockRumResourceAttributesProvider
+            rumResourceAttributesProvider = mockRumResourceAttributesProvider,
+            datadogContextProvider = mockDatadogContextProvider
         )
         val fakeClient = HttpClient(mockEngine) {
             install(testedPlugin.buildClientPlugin())
@@ -999,13 +1026,19 @@ class DatadogKtorPluginTest {
         assertThat(mockEngine.requestHistory.first().headers)
             .run {
                 val rumSessionId = fakeRumSessionId
-                val shouldInjectRumSessionId = with(fakeTracingHeaderTypes) {
+                val userId = fakeUserId
+                val accountId = fakeAccountId
+                val shouldInjectExtraBaggage = with(fakeTracingHeaderTypes) {
                     contains(TracingHeaderType.DATADOG) || contains(TracingHeaderType.TRACECONTEXT)
                 }
-                if (shouldInjectRumSessionId) {
+                if (shouldInjectExtraBaggage) {
                     if (rumSessionId == null) hasNoRumSessionId() else hasRumSessionId(rumSessionId)
+                    if (userId == null) hasNoUserId() else hasUserId(userId)
+                    if (accountId == null) hasNoAccountId() else hasAccountId(accountId)
                 } else {
                     hasNoRumSessionId()
+                    hasNoUserId()
+                    hasNoAccountId()
                 }
             }
     }
@@ -1044,7 +1077,8 @@ class DatadogKtorPluginTest {
             traceIdGenerator = mockTraceIdGenerator,
             spanIdGenerator = mockSpanIdGenerator,
             rumSessionProvider = mockRumSessionProvider,
-            rumResourceAttributesProvider = mockRumResourceAttributesProvider
+            rumResourceAttributesProvider = mockRumResourceAttributesProvider,
+            datadogContextProvider = mockDatadogContextProvider
         )
 
         // When

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/test/HeadersAssert.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/test/HeadersAssert.kt
@@ -36,9 +36,7 @@ class HeadersAssert private constructor(private val actual: Headers) {
     fun hasRumSessionId(rumSessionId: String): HeadersAssert {
         val baggage = actual["baggage"]
         assertNotNull(baggage, "Baggage header is missing")
-        val rumSessionIdPair = baggage.split(",")
-            .map { it.substringBefore("=") to it.substringAfter("=") }
-            .firstOrNull { it.first == "session.id" }
+        val rumSessionIdPair = getW3CBaggagePair(baggage, "session.id")
         assertNotNull(rumSessionIdPair, "RUM session ID is missing, value of baggage header is $baggage")
         assertEquals(
             rumSessionId,
@@ -51,12 +49,60 @@ class HeadersAssert private constructor(private val actual: Headers) {
     fun hasNoRumSessionId(): HeadersAssert {
         val baggage = actual["baggage"]
         if (baggage != null) {
-            val rumSessionIdPair = baggage.split(",")
-                .map { it.substringBefore("=") to it.substringAfter("=") }
-                .firstOrNull { it.first == "session.id" }
+            val rumSessionIdPair = getW3CBaggagePair(baggage, "session.id")
             assertNull(rumSessionIdPair, "Expected headers to not have RUM session ID, but was $rumSessionIdPair")
         }
         return this
+    }
+
+    fun hasUserId(userId: String): HeadersAssert {
+        val baggage = actual["baggage"]
+        assertNotNull(baggage, "Baggage header is missing")
+        val userIdPair = getW3CBaggagePair(baggage, "user.id")
+        assertNotNull(userIdPair, "User ID is missing, value of baggage header is $baggage")
+        assertEquals(
+            userId,
+            userIdPair.second,
+            "Expected user ID to be $userId, but was ${userIdPair.second}"
+        )
+        return this
+    }
+
+    fun hasNoUserId(): HeadersAssert {
+        val baggage = actual["baggage"]
+        if (baggage != null) {
+            val userIdPair = getW3CBaggagePair(baggage, "user.id")
+            assertNull(userIdPair, "Expected headers to not have user ID, but was $userIdPair")
+        }
+        return this
+    }
+
+    fun hasAccountId(accountId: String): HeadersAssert {
+        val baggage = actual["baggage"]
+        assertNotNull(baggage, "Baggage header is missing")
+        val accountIdPair = getW3CBaggagePair(baggage, "account.id")
+        assertNotNull(accountIdPair, "Account ID is missing, value of baggage header is $baggage")
+        assertEquals(
+            accountId,
+            accountIdPair.second,
+            "Expected account ID to be $accountId, but was ${accountIdPair.second}"
+        )
+        return this
+    }
+
+    fun hasNoAccountId(): HeadersAssert {
+        val baggage = actual["baggage"]
+        if (baggage != null) {
+            val accountIdPair = getW3CBaggagePair(baggage, "account.id")
+            assertNull(accountIdPair, "Expected headers to not have account ID, but was $accountIdPair")
+        }
+        return this
+    }
+
+    private fun getW3CBaggagePair(baggage: String, name: String): Pair<String, String>? {
+        return baggage.split(",")
+            .map { it.substringBefore("=") to it.substringAfter("=") }
+            .firstOrNull { it.first == name }
     }
 
     private fun traceContextAssert(format: TracingHeaderType): TraceContextAssert<Headers> = when (format) {


### PR DESCRIPTION
### What does this PR do?

This PR adds User ID and Account ID to the W3C `baggage` header the same way we already add RUM Session ID.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

