### PR TITLE
RUM-7500: Build iOS native modules only once

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,14 +160,8 @@ sample-app-build-ios:
     BUILD_DESTINATION: "platform=iOS Simulator,name=iPhone 15 Pro Max,OS=17.5"
   script:
     - pod repo update
-    - export DD_AGENT_PATH="$(pwd)/$DD_JAVA_AGENT_FILE"
-    # by some reason without this line xcodebuild below fails
-    - ./gradlew :core:podBuildDatadogCoreIosSimulator
-      :core:podBuildDatadogCrashReportingIosSimulator
-      :features:rum:podBuildDatadogRUMIosSimulator
-      :features:logs:podBuildDatadogLogsIosSimulator
-      :features:session-replay:podBuildDatadogSessionReplayIosSimulator
-      --no-daemon -Dorg.gradle.jvmargs=-javaagent:$DD_AGENT_PATH=$DD_COMMON_AGENT_CONFIG
+    # by some reason if we build Datadog pods from inside xcodebuild invocation, xcodebuild will crash (only on CI, not in local)
+    - ./gradlew :buildDatadogPods
     - xcodebuild -project sample/appleApp/appleApp.xcodeproj -destination "$BUILD_DESTINATION" -scheme "Sample iOS" build | xcbeautify --preserve-unbeautified
 
 sample-app-build-tvos:
@@ -178,14 +172,8 @@ sample-app-build-tvos:
     BUILD_DESTINATION: "platform=tvOS Simulator,name=Apple TV,OS=17.5"
   script:
     - pod repo update
-    - export DD_AGENT_PATH="$(pwd)/$DD_JAVA_AGENT_FILE"
-    # temporary workaround for RUM-4282
-    # by some reason without this line xcodebuild below fails
-    - ./gradlew :core:podBuildDatadogCoreTvosSimulator
-      :core:podBuildDatadogCrashReportingTvosSimulator
-      :features:rum:podBuildDatadogRUMTvosSimulator
-      :features:logs:podBuildDatadogLogsTvosSimulator
-      --no-daemon -Dorg.gradle.jvmargs=-javaagent:$DD_AGENT_PATH=$DD_COMMON_AGENT_CONFIG
+    # by some reason if we build Datadog pods from inside xcodebuild invocation, xcodebuild will crash (only on CI, not in local)
+    - ./gradlew :buildDatadogPods
     - xcodebuild -project sample/appleApp/appleApp.xcodeproj -destination "$BUILD_DESTINATION" -scheme "Sample tvOS" build | xcbeautify --preserve-unbeautified
 
 sample-app-build-android:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,13 @@ plugins {
     alias(libs.plugins.mokkery) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.nexusPublish)
+    id("datadog-ios-build-pods")
     // false - just to load classes into a classpath
     id("datadog-build-config") apply false
+}
+
+datadogPodsBuild {
+    podVersion.set(libs.versions.datadog.ios.get())
 }
 
 nexusPublishing {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,9 +11,9 @@ import kotlin.io.path.pathString
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
+    id("datadog-ios-frameworks")
     alias(libs.plugins.dependencyLicense)
     id("api-surface")
     id("transitive-dependencies")
@@ -44,47 +44,16 @@ val generateLibConfigTask = tasks.register("generateLibConfig", Sync::class) {
     into(generatedDirectory)
 }
 
-kotlin {
-
-    cocoapods {
-        // need to build with XCode 15
-        ios.deploymentTarget = "12.0"
-        tvos.deploymentTarget = "12.0"
-        noPodspec()
-
-        framework {
-            baseName = "DatadogKMPCore"
-        }
-
-        val compilerOptionFlag = "-compiler-option"
-        val modulesFlag = "-fmodules"
-        pod("DatadogCore") {
-            extraOpts += listOf(
-                // proposed by KMP because of the @import usage in the binary
-                compilerOptionFlag,
-                modulesFlag
-            )
-            version = libs.versions.datadog.ios.get()
-        }
-        // TODO RUM-11618 DatadogInternal cannot be used
-//        pod("DatadogInternal") {
-//            extraOpts += listOf(
-//                // proposed by KMP because of the @import usage in the binary
-//                compilerOptionFlag,
-//                modulesFlag
-//            )
-//            version = libs.versions.datadog.ios.get()
-//        }
-        pod("DatadogCrashReporting") {
-            extraOpts += listOf(
-                // proposed by KMP because of the @import usage in the binary
-                compilerOptionFlag,
-                modulesFlag
-            )
-            version = libs.versions.datadog.ios.get()
-        }
+datadogFrameworks {
+    framework("DatadogCore") {
+        linkOnly = false
     }
+    framework("DatadogCrashReporting") {
+        linkOnly = false
+    }
+}
 
+kotlin {
     targets.all {
         if (this is KotlinNativeTarget && konanTarget.family.isAppleFamily) {
             compilations.getByName("main") {

--- a/features/logs/build.gradle.kts
+++ b/features/logs/build.gradle.kts
@@ -9,9 +9,9 @@ import dev.mokkery.MockMode
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
+    id("datadog-ios-frameworks")
     alias(libs.plugins.dependencyLicense)
     id("api-surface")
     id("transitive-dependencies")
@@ -23,38 +23,19 @@ plugins {
     signing
 }
 
-kotlin {
-
-    cocoapods {
-        // need to build with XCode 15
-        ios.deploymentTarget = "12.0"
-        tvos.deploymentTarget = "12.0"
-        noPodspec()
-
-        framework {
-            baseName = "DatadogKMPLogs"
-        }
-
-        pod("DatadogLogs") {
-            extraOpts += listOf(
-                // proposed by KMP because of the @import usage in the binary
-                "-compiler-option",
-                "-fmodules"
-            )
-            version = libs.versions.datadog.ios.get()
-        }
-        // need to link it only for the tests so far (maybe this will change
-        // later with SDK setup changes)
-        pod("DatadogCore") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCrashReporting") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
+datadogFrameworks {
+    framework("DatadogLogs") {
+        linkOnly = false
     }
+    framework("DatadogCore") {
+        linkOnly = true
+    }
+    framework("DatadogCrashReporting") {
+        linkOnly = true
+    }
+}
 
+kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(libs.datadog.android.logs)

--- a/features/rum/build.gradle.kts
+++ b/features/rum/build.gradle.kts
@@ -9,9 +9,9 @@ import dev.mokkery.MockMode
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
+    id("datadog-ios-frameworks")
     alias(libs.plugins.dependencyLicense)
     id("api-surface")
     id("transitive-dependencies")
@@ -23,46 +23,25 @@ plugins {
     signing
 }
 
-kotlin {
-
-    cocoapods {
-        // need to build with XCode 15
-        ios.deploymentTarget = "12.0"
-        tvos.deploymentTarget = "12.0"
-        noPodspec()
-
-        framework {
-            baseName = "DatadogKMPRUM"
-        }
-
-        val compilerOptionFlag = "-compiler-option"
-        pod("DatadogRUM") {
-            extraOpts += listOf(
-                // proposed by KMP because of the @import usage in the binary
-                compilerOptionFlag,
+datadogFrameworks {
+    framework("DatadogRUM") {
+        linkOnly = false
+        compilerOpts.addAll(
+            listOf(
                 "-fmodules",
-                // see https://youtrack.jetbrains.com/issue/KT-61799
-                // TL;DR: Kotlin interop adds "<ClassName>Meta" class for every "<ClassName>" class,
-                // so since there is DDRUMErrorEventError, it generates DDRUMErrorEventErrorMeta, but such
-                // class is already declared, leading to error: 'DDRUMErrorEventErrorMeta' is going
-                // to be declared twice
-                compilerOptionFlag,
                 "-DDDRUMErrorEventErrorMeta=DDRUMErrorEventErrorMetaInfo"
             )
-            version = libs.versions.datadog.ios.get()
-        }
-        // need to link it only for the tests so far (maybe this will change
-        // later with SDK setup changes)
-        pod("DatadogCore") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCrashReporting") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
+        )
     }
+    framework("DatadogCore") {
+        linkOnly = true
+    }
+    framework("DatadogCrashReporting") {
+        linkOnly = true
+    }
+}
 
+kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(libs.datadog.android.rum)

--- a/features/session-replay/build.gradle.kts
+++ b/features/session-replay/build.gradle.kts
@@ -8,9 +8,9 @@ import dev.mokkery.MockMode
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
+    id("datadog-ios-frameworks")
     alias(libs.plugins.dependencyLicense)
     id("api-surface")
     id("transitive-dependencies")
@@ -21,35 +21,20 @@ plugins {
     signing
 }
 
-kotlin {
-
-    cocoapods {
-        // need to build with XCode 15
-        ios.deploymentTarget = "12.0"
-        noPodspec()
-
-        framework {
-            baseName = "DatadogKMPSessionReplay"
-        }
-
-        pod("DatadogSessionReplay") {
-            extraOpts += listOf(
-                // proposed by KMP because of the @import usage in the binary
-                "-compiler-option",
-                "-fmodules"
-            )
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCore") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCrashReporting") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
+datadogFrameworks {
+    includeObjcCategoryLinkerFlag = true
+    framework("DatadogSessionReplay") {
+        linkOnly = false
     }
+    framework("DatadogCore") {
+        linkOnly = true
+    }
+    framework("DatadogCrashReporting") {
+        linkOnly = true
+    }
+}
 
+kotlin {
     sourceSets {
         androidMain.dependencies {
             // need to be API, because in androidMain we have extension methods which

--- a/features/webview/build.gradle.kts
+++ b/features/webview/build.gradle.kts
@@ -10,9 +10,9 @@ import org.jetbrains.kotlin.konan.target.Family
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
+    id("datadog-ios-frameworks")
     alias(libs.plugins.dependencyLicense)
     id("api-surface")
     id("transitive-dependencies")
@@ -23,32 +23,19 @@ plugins {
     signing
 }
 
-kotlin {
-
-    cocoapods {
-        // need to build with XCode 15
-        ios.deploymentTarget = "12.0"
-        noPodspec()
-
-        framework {
-            baseName = "DatadogKMPWebView"
-        }
-        pod("DatadogWebViewTracking") {
-            // TODO RUM-5208 by some reason ootb bindings for DatadogWebViewTracking are not generated correctly, so
-            //  we go with a custom header (see custom cinterop below)
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCore") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCrashReporting") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
+datadogFrameworks {
+    framework("DatadogWebViewTracking") {
+        linkOnly = true
     }
+    framework("DatadogCore") {
+        linkOnly = true
+    }
+    framework("DatadogCrashReporting") {
+        linkOnly = true
+    }
+}
 
+kotlin {
     targets.all {
         if (this is KotlinNativeTarget && konanTarget.family == Family.IOS) {
             compilations.getByName("main") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@ org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\=
 org.gradle.caching=true
 org.gradle.configuration-cache=false
 
+# Kotlin Multiplatform
+kotlin.mpp.enableCInteropCommonization=true
+
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true

--- a/integrations/ktor/build.gradle.kts
+++ b/integrations/ktor/build.gradle.kts
@@ -8,9 +8,9 @@ import dev.mokkery.MockMode
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
+    id("datadog-ios-frameworks")
     alias(libs.plugins.dependencyLicense)
     id("api-surface")
     id("transitive-dependencies")
@@ -21,34 +21,19 @@ plugins {
     signing
 }
 
-kotlin {
-
-    cocoapods {
-        // need to build with XCode 15
-        ios.deploymentTarget = "12.0"
-        tvos.deploymentTarget = "12.0"
-        noPodspec()
-
-        framework {
-            baseName = "DatadogKMPKtor"
-        }
-
-        // need to link it only for the tests so far (maybe this will change
-        // later with SDK setup changes)
-        pod("DatadogRUM") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCore") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCrashReporting") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
+datadogFrameworks {
+    framework("DatadogRUM") {
+        linkOnly = true
     }
+    framework("DatadogCore") {
+        linkOnly = true
+    }
+    framework("DatadogCrashReporting") {
+        linkOnly = true
+    }
+}
 
+kotlin {
     sourceSets {
         commonMain.dependencies {
             api(projects.core)

--- a/integrations/ktor3/build.gradle.kts
+++ b/integrations/ktor3/build.gradle.kts
@@ -9,9 +9,9 @@ import java.nio.file.Paths
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
     id("datadog-build-config")
+    id("datadog-ios-frameworks")
     alias(libs.plugins.dependencyLicense)
     id("api-surface")
     id("transitive-dependencies")
@@ -22,34 +22,19 @@ plugins {
     signing
 }
 
-kotlin {
-
-    cocoapods {
-        // need to build with XCode 15
-        ios.deploymentTarget = "12.0"
-        tvos.deploymentTarget = "12.0"
-        noPodspec()
-
-        framework {
-            baseName = "DatadogKMPKtor3"
-        }
-
-        // need to link it only for the tests so far (maybe this will change
-        // later with SDK setup changes)
-        pod("DatadogRUM") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCore") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
-        pod("DatadogCrashReporting") {
-            linkOnly = true
-            version = libs.versions.datadog.ios.get()
-        }
+datadogFrameworks {
+    framework("DatadogRUM") {
+        linkOnly = true
     }
+    framework("DatadogCore") {
+        linkOnly = true
+    }
+    framework("DatadogCrashReporting") {
+        linkOnly = true
+    }
+}
 
+kotlin {
     sourceSets {
         commonMain {
             kotlin {

--- a/tools/build-plugins/build.gradle.kts
+++ b/tools/build-plugins/build.gradle.kts
@@ -71,5 +71,13 @@ gradlePlugin {
             id = "json-schema-generator"
             implementationClass = "com.datadog.build.plugin.jsonschema.GenerateJsonSchemaPlugin"
         }
+        register("DatadogPodsBuildPlugin") {
+            id = "datadog-ios-build-pods"
+            implementationClass = "com.datadog.build.plugin.iosnative.DatadogPodsBuildPlugin"
+        }
+        register("DatadogFrameworksPlugin") {
+            id = "datadog-ios-frameworks"
+            implementationClass = "com.datadog.build.plugin.iosnative.DatadogFrameworksPlugin"
+        }
     }
 }

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/config/DatadogProjectConfigurationPlugin.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/config/DatadogProjectConfigurationPlugin.kt
@@ -14,12 +14,10 @@ import com.datadog.build.utils.taskConfig
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
@@ -29,9 +27,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
-import org.jetbrains.kotlin.gradle.plugin.cocoapods.CocoapodsExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.targets.native.KotlinNativeSimulatorTestRun
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -177,46 +173,7 @@ private fun Project.applyKotlinMultiplatformConfig(configExtension: DatadogBuild
                         apiVersion = configExtension.kotlinVersionOrDefault.version
                     }
                 }
-
-                applySwiftCompatibilityLinkingWorkaround(this@apply)
             }
-        }
-}
-
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
-private fun applySwiftCompatibilityLinkingWorkaround(kmpExtension: KotlinMultiplatformExtension) {
-    (kmpExtension as ExtensionAware).extensions
-        .findByType<CocoapodsExtension>()
-        ?.pods
-        ?.matching { it.name == "DatadogCrashReporting" }
-        ?.all {
-            kmpExtension
-                .targets
-                .withType<KotlinNativeTarget>()
-                .matching { it.konanTarget.family.isAppleFamily }
-                .all {
-                    val swiftCompatibilityArgs = if (System.getenv("DEVELOPER_DIR") != null) {
-                        // case env injected from XCode
-                        "-L${System.getenv("DEVELOPER_DIR")}/Toolchains/XcodeDefault.xctoolchain" +
-                            "/usr/lib/swift/${System.getenv("PLATFORM_NAME")}"
-                    } else {
-                        "-U __swift_FORCE_LOAD_\$_swiftCompatibility50 " +
-                            "-U __swift_FORCE_LOAD_\$_swiftCompatibility51 " +
-                            "-U __swift_FORCE_LOAD_\$_swiftCompatibility56 " +
-                            "-U __swift_FORCE_LOAD_\$_swiftCompatibilityConcurrency " +
-                            "-U __swift_FORCE_LOAD_\$_swiftCompatibilityDynamicReplacements"
-                    }
-                    compilerOptions {
-                        freeCompilerArgs.addAll(
-                            listOf(
-                                "-linker-options",
-                                // TODO RUM-6047 Kotlin Compiler cannot locate these during the linking
-                                //  done via pods integration
-                                swiftCompatibilityArgs
-                            )
-                        )
-                    }
-                }
         }
 }
 
@@ -246,7 +203,6 @@ private fun Project.applyApplicationAndroidConfig(configExtension: DatadogBuildC
                 java.srcDir("src/$name/kotlin")
             }
 
-            @Suppress("UnstableApiUsage")
             testOptions {
                 unitTests.isReturnDefaultValues = true
             }
@@ -275,7 +231,6 @@ private fun Project.applyLibraryAndroidConfig(configExtension: DatadogBuildConfi
                 java.srcDir("src/$name/kotlin")
             }
 
-            @Suppress("UnstableApiUsage")
             testOptions {
                 unitTests.isReturnDefaultValues = true
             }

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/DatadogFrameworksExtension.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/DatadogFrameworksExtension.kt
@@ -1,0 +1,52 @@
+package com.datadog.build.plugin.iosnative
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.kotlin.dsl.domainObjectContainer
+import org.gradle.kotlin.dsl.listProperty
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.setProperty
+import org.jetbrains.kotlin.konan.target.Family
+import javax.inject.Inject
+
+abstract class DatadogNativeFrameworkSpec @Inject constructor(
+    val name: String,
+    objects: ObjectFactory
+) {
+    val linkOnly: Property<Boolean> = objects.property<Boolean>()
+        .convention(false)
+    val packageName: Property<String> = objects.property<String>()
+        .convention("cocoapods.$name")
+    val compilerOpts: ListProperty<String> = objects.listProperty<String>()
+        .convention(listOf("-fmodules"))
+    val targetFamilies: SetProperty<Family> = objects.setProperty<Family>()
+        .convention(setOf(Family.IOS, Family.TVOS))
+}
+
+abstract class DatadogFrameworksExtension @Inject constructor(objects: ObjectFactory) {
+    val rootBuildTaskName: Property<String> = objects.property<String>()
+        .convention("buildDatadogPods")
+    val iosUmbrellaFramework: Property<String> = objects.property<String>()
+        .convention("Pods_${DatadogPodsBuildPlugin.SYNTHETIC_IOS_TARGET_NAME}")
+    val tvosUmbrellaFramework: Property<String> = objects.property<String>()
+        .convention("Pods_${DatadogPodsBuildPlugin.SYNTHETIC_TVOS_TARGET_NAME}")
+    val extraFrameworks: ListProperty<String> = objects.listProperty<String>()
+        .convention(emptyList())
+    val includeSwiftCompatibilityWorkaround: Property<Boolean> = objects.property<Boolean>()
+        .convention(true)
+    val includeObjcCategoryLinkerFlag: Property<Boolean> = objects.property<Boolean>()
+        .convention(false)
+
+    val frameworks: NamedDomainObjectContainer<DatadogNativeFrameworkSpec> =
+        objects.domainObjectContainer(DatadogNativeFrameworkSpec::class) { name ->
+            objects.newInstance(name)
+        }
+
+    fun framework(name: String, configure: DatadogNativeFrameworkSpec.() -> Unit) {
+        configure.invoke(frameworks.maybeCreate(name))
+    }
+}

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/DatadogFrameworksPlugin.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/DatadogFrameworksPlugin.kt
@@ -1,0 +1,125 @@
+package com.datadog.build.plugin.iosnative
+
+import com.datadog.build.plugin.iosnative.tasks.GenerateDatadogCInteropDefsTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.Family
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+class DatadogFrameworksPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        val extension = target.extensions.create<DatadogFrameworksExtension>("datadogFrameworks")
+
+        target.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+            configureKmpProject(target, extension)
+        }
+    }
+
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    private fun configureKmpProject(project: Project, extension: DatadogFrameworksExtension) {
+        val kmpExtension = project.extensions.getByType<KotlinMultiplatformExtension>()
+
+        project.afterEvaluate {
+            val rootBuildTask = project.rootProject.tasks.named(extension.rootBuildTaskName.get())
+            val cinteropFrameworks = extension.frameworks.filter { !it.linkOnly.get() }
+            val generateDefsTask = project.tasks.register<GenerateDatadogCInteropDefsTask>(
+                "generateDatadogCInteropDefs"
+            ) {
+                frameworkNames.set(cinteropFrameworks.map { it.name })
+                outputDirectory.set(project.layout.buildDirectory.dir("generated/datadog-cinterop-defs"))
+            }
+
+            kmpExtension.targets.withType<KotlinNativeTarget>().all {
+                if (!konanTarget.family.isAppleFamily) return@all
+
+                val frameworksDirectoryPath = project.rootProject.layout.buildDirectory
+                    .dir(
+                        when (konanTarget) {
+                            KonanTarget.IOS_ARM64 -> "datadog-pods-build/ios-device"
+                            KonanTarget.IOS_X64, KonanTarget.IOS_SIMULATOR_ARM64 -> "datadog-pods-build/ios-simulator"
+                            KonanTarget.TVOS_ARM64 -> "datadog-pods-build/tvos-device"
+                            KonanTarget.TVOS_X64, KonanTarget.TVOS_SIMULATOR_ARM64 ->
+                                "datadog-pods-build/tvos-simulator"
+                            else -> error("Unsupported Apple target for Datadog root pods linkage: $konanTarget")
+                        }
+                    )
+                    .get()
+                    .asFile
+                    .absolutePath
+
+                val mainCompilation = compilations.getByName("main")
+                cinteropFrameworks
+                    .filter { it.targetFamilies.get().contains(konanTarget.family) }
+                    .forEach { spec ->
+                        mainCompilation.cinterops.maybeCreate(spec.name).apply {
+                            defFile(
+                                generateDefsTask.map { task ->
+                                    task.outputDirectory.file("${spec.name}.def").get().asFile
+                                }
+                            )
+                            packageName(spec.packageName.get())
+                            compilerOpts(*(spec.compilerOpts.get() + "-F$frameworksDirectoryPath").toTypedArray())
+                        }
+                    }
+
+                val umbrellaFramework = when (konanTarget.family) {
+                    Family.IOS -> extension.iosUmbrellaFramework.get()
+                    Family.TVOS -> extension.tvosUmbrellaFramework.get()
+                    else -> error("Unsupported Apple family for Datadog frameworks processing: ${konanTarget.family}")
+                }
+
+                val frameworkArgs = buildString {
+                    append("-F$frameworksDirectoryPath -framework $umbrellaFramework")
+                    extension.frameworks.forEach { framework ->
+                        append(" -framework ${framework.name}")
+                    }
+                    extension.extraFrameworks.get().forEach { framework ->
+                        append(" -framework $framework")
+                    }
+                    if (extension.includeObjcCategoryLinkerFlag.get()) {
+                        append(" -ObjC")
+                    }
+                    if (extension.includeSwiftCompatibilityWorkaround.get()) {
+                        append(" ")
+                        append(
+                            "-U __swift_FORCE_LOAD_\$_swiftCompatibility50 " +
+                                "-U __swift_FORCE_LOAD_\$_swiftCompatibility51 " +
+                                "-U __swift_FORCE_LOAD_\$_swiftCompatibility56 " +
+                                "-U __swift_FORCE_LOAD_\$_swiftCompatibilityConcurrency " +
+                                "-U __swift_FORCE_LOAD_\$_swiftCompatibilityDynamicReplacements " +
+                                "-U __swift_FORCE_LOAD_\$_swiftCompatibilityPacks"
+                        )
+                    }
+                }
+
+                compilerOptions {
+                    freeCompilerArgs.addAll(
+                        listOf(
+                            "-linker-options",
+                            frameworkArgs
+                        )
+                    )
+                }
+
+                binaries.configureEach {
+                    linkTaskProvider.configure {
+                        dependsOn(rootBuildTask, generateDefsTask)
+                    }
+                }
+            }
+
+            project.tasks.configureEach {
+                if (name.startsWith("cinterop")) {
+                    dependsOn(rootBuildTask, generateDefsTask)
+                }
+            }
+        }
+    }
+}

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/DatadogPodsBuildExtension.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/DatadogPodsBuildExtension.kt
@@ -1,0 +1,36 @@
+package com.datadog.build.plugin.iosnative
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.listProperty
+import org.gradle.kotlin.dsl.property
+import javax.inject.Inject
+
+abstract class DatadogPodsBuildExtension @Inject constructor(objects: ObjectFactory) {
+    val podVersion: Property<String> = objects.property<String>()
+    val iosDeploymentTarget: Property<String> = objects.property<String>()
+        .convention("12.0")
+    val tvosDeploymentTarget: Property<String> = objects.property<String>()
+        .convention("12.0")
+    val iosPods: ListProperty<String> = objects.listProperty<String>()
+        .convention(
+            listOf(
+                "DatadogCore",
+                "DatadogCrashReporting",
+                "DatadogLogs",
+                "DatadogRUM",
+                "DatadogWebViewTracking",
+                "DatadogSessionReplay"
+            )
+        )
+    val tvosPods: ListProperty<String> = objects.listProperty<String>()
+        .convention(
+            listOf(
+                "DatadogCore",
+                "DatadogCrashReporting",
+                "DatadogLogs",
+                "DatadogRUM"
+            )
+        )
+}

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/DatadogPodsBuildPlugin.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/DatadogPodsBuildPlugin.kt
@@ -1,0 +1,142 @@
+package com.datadog.build.plugin.iosnative
+
+import com.datadog.build.ProjectConfig
+import com.datadog.build.plugin.iosnative.tasks.CheckNoDatadogPodsOutsideRootTask
+import com.datadog.build.plugin.iosnative.tasks.GenerateSyntheticDatadogPodspecTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.Exec
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.register
+import java.io.File
+
+class DatadogPodsBuildPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        val extension = target.extensions.create<DatadogPodsBuildExtension>("datadogPodsBuild")
+
+        val syntheticPodsRootDir = target.layout.buildDirectory.dir("datadog-pods")
+        val podsBuildDir = target.layout.buildDirectory.dir("datadog-pods-build")
+
+        val generateSyntheticDatadogPodspec = target.tasks.register<GenerateSyntheticDatadogPodspecTask>(
+            "generateSyntheticDatadogPodspec"
+        ) {
+            outputDirectory.set(syntheticPodsRootDir)
+            podVersion.set(extension.podVersion)
+            iosDeploymentTarget.set(extension.iosDeploymentTarget)
+            tvosDeploymentTarget.set(extension.tvosDeploymentTarget)
+            iosPods.set(extension.iosPods)
+            tvosPods.set(extension.tvosPods)
+            syntheticPodVersion.set(ProjectConfig.VERSION.name)
+        }
+
+        val installDatadogPods = target.tasks.register<Exec>("installDatadogPods") {
+            dependsOn(generateSyntheticDatadogPodspec)
+            workingDir(syntheticPodsRootDir)
+            commandLine(findPodExecutable(), "install", "--repo-update")
+            inputs.file(syntheticPodsRootDir.map { it.file("Podfile") })
+            inputs.file(syntheticPodsRootDir.map { it.file("${SYNTHETIC_IOS_TARGET_NAME}Root.podspec") })
+            inputs.file(syntheticPodsRootDir.map { it.file("${SYNTHETIC_TVOS_TARGET_NAME}Root.podspec") })
+            outputs.file(syntheticPodsRootDir.map { it.file("Podfile.lock") })
+            outputs.dir(syntheticPodsRootDir.map { it.dir("Pods") })
+        }
+
+        fun registerPodBuildTask(
+            taskName: String,
+            scheme: String,
+            sdk: String,
+            destination: String,
+            outputSubdirectory: String
+        ) = target.tasks.register<Exec>(taskName) {
+            dependsOn(installDatadogPods)
+            val outputDir = podsBuildDir.map { it.dir(outputSubdirectory) }
+            workingDir(syntheticPodsRootDir)
+            commandLine(
+                "xcodebuild",
+                "-project", "Pods/Pods.xcodeproj",
+                "-scheme", scheme,
+                "-configuration", "Release",
+                "-sdk", sdk,
+                "-destination", destination,
+                "ONLY_ACTIVE_ARCH=NO",
+                "SKIP_INSTALL=NO",
+                "BUILD_LIBRARY_FOR_DISTRIBUTION=YES",
+                "CONFIGURATION_BUILD_DIR=${outputDir.get().asFile.absolutePath}"
+            )
+            inputs.file(syntheticPodsRootDir.map { it.file("Podfile.lock") })
+            outputs.dir(outputDir)
+        }
+
+        val buildDatadogIosDevicePods = registerPodBuildTask(
+            taskName = "buildDatadogIosDevicePods",
+            scheme = "Pods-$SYNTHETIC_IOS_TARGET_NAME",
+            sdk = "iphoneos",
+            destination = "generic/platform=iOS",
+            outputSubdirectory = "ios-device"
+        )
+
+        val buildDatadogIosSimulatorPods = registerPodBuildTask(
+            taskName = "buildDatadogIosSimulatorPods",
+            scheme = "Pods-$SYNTHETIC_IOS_TARGET_NAME",
+            sdk = "iphonesimulator",
+            destination = "generic/platform=iOS Simulator",
+            outputSubdirectory = "ios-simulator"
+        )
+
+        val buildDatadogTvosDevicePods = registerPodBuildTask(
+            taskName = "buildDatadogTvosDevicePods",
+            scheme = "Pods-$SYNTHETIC_TVOS_TARGET_NAME",
+            sdk = "appletvos",
+            destination = "generic/platform=tvOS",
+            outputSubdirectory = "tvos-device"
+        )
+
+        val buildDatadogTvosSimulatorPods = registerPodBuildTask(
+            taskName = "buildDatadogTvosSimulatorPods",
+            scheme = "Pods-$SYNTHETIC_TVOS_TARGET_NAME",
+            sdk = "appletvsimulator",
+            destination = "generic/platform=tvOS Simulator",
+            outputSubdirectory = "tvos-simulator"
+        )
+
+        target.tasks.register("buildDatadogPods") {
+            group = "cocoapods"
+            description = "Generates a synthetic podspec, installs Datadog pods, and builds iOS/tvOS pods once at root."
+            dependsOn(
+                buildDatadogIosDevicePods,
+                buildDatadogIosSimulatorPods,
+                buildDatadogTvosDevicePods,
+                buildDatadogTvosSimulatorPods
+            )
+        }
+
+        target.tasks.register<CheckNoDatadogPodsOutsideRootTask>("forbidDatadogPodsOutsideRoot") {
+            group = "verification"
+            description = "Fails if Datadog pods are declared in subproject build scripts."
+            val projectBuildFiles = target.provider {
+                target.rootDir
+                    .walkTopDown()
+                    .filter { file ->
+                        file.isFile &&
+                            file.name == "build.gradle.kts" &&
+                            file.parentFile != target.rootDir &&
+                            !file.invariantSeparatorsPath.contains("/build/")
+                    }
+                    .toList()
+            }
+            buildFiles.setFrom(projectBuildFiles)
+        }
+    }
+
+    private fun findPodExecutable(): String {
+        val locations = listOf("/usr/local/bin/pod", "/opt/homebrew/bin/pod", "/usr/bin/pod")
+        for (location in locations) {
+            if (File(location).exists()) return location
+        }
+        return "pod"
+    }
+
+    companion object {
+        const val SYNTHETIC_IOS_TARGET_NAME = "DatadogSyntheticIOS"
+        const val SYNTHETIC_TVOS_TARGET_NAME = "DatadogSyntheticTVOS"
+    }
+}

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/tasks/CheckNoDatadogPodsOutsideRootTask.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/tasks/CheckNoDatadogPodsOutsideRootTask.kt
@@ -1,0 +1,32 @@
+package com.datadog.build.plugin.iosnative.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+abstract class CheckNoDatadogPodsOutsideRootTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val buildFiles: ConfigurableFileCollection
+
+    @TaskAction
+    fun verify() {
+        val datadogPodRegex = Regex("""pod\("Datadog[A-Za-z0-9]*"\)""")
+        val offenders = buildFiles.files.filter { file ->
+            datadogPodRegex.containsMatchIn(file.readText())
+        }
+        if (offenders.isNotEmpty()) {
+            val root = project.rootDir
+            val formatted = offenders.joinToString(separator = "\n") { it.relativeTo(root).path }
+            throw GradleException(
+                "Datadog pod declarations must live only in root synthetic pods setup.\n" +
+                    "Found in:\n$formatted"
+            )
+        }
+    }
+}

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/tasks/GenerateDatadogCInteropDefsTask.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/tasks/GenerateDatadogCInteropDefsTask.kt
@@ -1,0 +1,35 @@
+package com.datadog.build.plugin.iosnative.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class GenerateDatadogCInteropDefsTask : DefaultTask() {
+
+    @get:Input
+    abstract val frameworkNames: ListProperty<String>
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val outputDir = outputDirectory.get().asFile
+        outputDir.mkdirs()
+
+        frameworkNames.get().forEach { frameworkName ->
+            val defFile = outputDir.resolve("$frameworkName.def")
+            defFile.writeText(
+                """
+                |language = Objective-C
+                |modules = $frameworkName
+                |linkerOpts = -framework $frameworkName
+                |
+                """.trimMargin()
+            )
+        }
+    }
+}

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/tasks/GenerateSyntheticDatadogPodspecTask.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/iosnative/tasks/GenerateSyntheticDatadogPodspecTask.kt
@@ -1,0 +1,124 @@
+package com.datadog.build.plugin.iosnative.tasks
+
+import com.datadog.build.plugin.iosnative.DatadogPodsBuildPlugin
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+abstract class GenerateSyntheticDatadogPodspecTask : DefaultTask() {
+
+    @get:Input
+    abstract val podVersion: Property<String>
+
+    @get:Input
+    abstract val iosDeploymentTarget: Property<String>
+
+    @get:Input
+    abstract val tvosDeploymentTarget: Property<String>
+
+    @get:Input
+    abstract val iosPods: ListProperty<String>
+
+    @get:Input
+    abstract val tvosPods: ListProperty<String>
+
+    @get:Input
+    abstract val syntheticPodVersion: Property<String>
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val rootDirFile = outputDirectory.get().asFile
+        val sourcesDir = File(rootDirFile, "Sources")
+        sourcesDir.mkdirs()
+
+        val iosPodspecFile = File(rootDirFile, "${DatadogPodsBuildPlugin.SYNTHETIC_IOS_TARGET_NAME}Root.podspec")
+        val iosPodDependencies = iosPods.get()
+            .joinToString(separator = "\n") { "  s.dependency '$it', '${podVersion.get()}'" }
+
+        iosPodspecFile.writeText(
+            """
+            |Pod::Spec.new do |s|
+            |  s.name = '${DatadogPodsBuildPlugin.SYNTHETIC_IOS_TARGET_NAME}Root'
+            |  s.version = '${syntheticPodVersion.get()}'
+            |  s.summary = 'Synthetic Datadog pod to prebuild native dependencies for KMP.'
+            |  s.homepage = 'https://www.datadoghq.com/'
+            |  s.license = { :type => 'Apache-2.0' }
+            |  s.author = { 'Datadog' => 'support@datadoghq.com' }
+            |  s.source = { :path => '.' }
+            |  s.ios.deployment_target = '${iosDeploymentTarget.get()}'
+            |  s.tvos.deployment_target = '${tvosDeploymentTarget.get()}'
+            |  s.source_files = 'Sources/**/*.{h,m,mm,swift}'
+            |
+            |$iosPodDependencies
+            |end
+            |
+            """.trimMargin()
+        )
+
+        val tvosPodspecFile = File(rootDirFile, "${DatadogPodsBuildPlugin.SYNTHETIC_TVOS_TARGET_NAME}Root.podspec")
+        val tvosPodDependencies = tvosPods.get()
+            .joinToString(separator = "\n") { "  s.dependency '$it', '${podVersion.get()}'" }
+        tvosPodspecFile.writeText(
+            """
+            |Pod::Spec.new do |s|
+            |  s.name = '${DatadogPodsBuildPlugin.SYNTHETIC_TVOS_TARGET_NAME}Root'
+            |  s.version = '${syntheticPodVersion.get()}'
+            |  s.summary = 'Synthetic Datadog pod to prebuild native dependencies for KMP.'
+            |  s.homepage = 'https://www.datadoghq.com/'
+            |  s.license = { :type => 'Apache-2.0' }
+            |  s.author = { 'Datadog' => 'support@datadoghq.com' }
+            |  s.source = { :path => '.' }
+            |  s.tvos.deployment_target = '${tvosDeploymentTarget.get()}'
+            |  s.source_files = 'Sources/**/*.{h,m,mm,swift}'
+            |
+            |$tvosPodDependencies
+            |end
+            |
+            """.trimMargin()
+        )
+
+        File(sourcesDir, "placeholder.m").writeText(
+            """
+            |void datadog_synthetic_pod_placeholder(void) {}
+            |
+            """.trimMargin()
+        )
+
+        File(rootDirFile, "Podfile").writeText(
+            """
+            |source 'https://cdn.cocoapods.org/'
+            |install! 'cocoapods', :integrate_targets => false
+            |use_frameworks! :linkage => :static
+            |
+            |target '${DatadogPodsBuildPlugin.SYNTHETIC_IOS_TARGET_NAME}' do
+            |  platform :ios, '${iosDeploymentTarget.get()}'
+            |  pod '${DatadogPodsBuildPlugin.SYNTHETIC_IOS_TARGET_NAME}Root', :path => '.'
+            |end
+            |
+            |target '${DatadogPodsBuildPlugin.SYNTHETIC_TVOS_TARGET_NAME}' do
+            |  platform :tvos, '${tvosDeploymentTarget.get()}'
+            |  pod '${DatadogPodsBuildPlugin.SYNTHETIC_TVOS_TARGET_NAME}Root', :path => '.'
+            |end
+            |
+            |post_install do |installer|
+            |  installer.pods_project.targets.each do |target|
+            |    target.build_configurations.each do |config|
+            |      config.build_settings['EXPANDED_CODE_SIGN_IDENTITY'] = ""
+            |      config.build_settings['CODE_SIGNING_REQUIRED'] = "NO"
+            |      config.build_settings['CODE_SIGNING_ALLOWED'] = "NO"
+            |    end
+            |  end
+            |end
+            |
+            """.trimMargin()
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR removes `cocoapods` KMP plugin, because otherwise we are building the same iOS native dependency several time (for each module). This is because `cocoapods` plugin doesn't support sharing binaries built between the modules (it is possible to setup a dedicated module just for that and then export binaries, but this is something subpar).

Instead, in this PR the approach is different: we are building frameworks once in the root of the project and then simply manually consuming them in the modules.

This greatly reduces initial project setup time.

For now we are still using cocoapods CLI, because with SPM/XCFrameworks the binaries provided by the iOS SDK repo are missing _some_ symbols for `x86_64` architecture.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

