### PR TITLE
RUM-15737: Support app startup activity predicate on Android

### DIFF
--- a/features/rum/api/androidMain/apiSurface
+++ b/features/rum/api/androidMain/apiSurface
@@ -3,6 +3,9 @@ actual object com.datadog.kmp.rum.Rum
 fun RumConfiguration.Builder.trackNonFatalAnrs(Boolean): RumConfiguration.Builder
 fun RumConfiguration.Builder.useViewTrackingStrategy(com.datadog.kmp.rum.tracking.ViewTrackingStrategy?): RumConfiguration.Builder
 fun RumConfiguration.Builder.trackUserInteractions(Array<com.datadog.kmp.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.kmp.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): RumConfiguration.Builder
+fun RumConfiguration.Builder.setAppStartupActivityPredicate(com.datadog.kmp.rum.startup.AppStartupActivityPredicate): RumConfiguration.Builder
+fun interface com.datadog.kmp.rum.startup.AppStartupActivityPredicate
+  fun shouldTrackStartup(android.app.Activity): Boolean
 class com.datadog.kmp.rum.tracking.AcceptAllActivities : ComponentPredicate<android.app.Activity>
   override fun accept(android.app.Activity): Boolean
   override fun getViewName(android.app.Activity): String?

--- a/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
+++ b/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
@@ -7,8 +7,10 @@
 package com.datadog.kmp.rum.configuration
 
 import com.datadog.android.rum.RumMonitor
+import com.datadog.kmp.rum.ExperimentalRumApi
 import com.datadog.kmp.rum.configuration.internal.AndroidRumConfigurationBuilder
 import com.datadog.kmp.rum.configuration.internal.PlatformRumConfigurationBuilder
+import com.datadog.kmp.rum.startup.AppStartupActivityPredicate
 import com.datadog.kmp.rum.tracking.InteractionPredicate
 import com.datadog.kmp.rum.tracking.ViewAttributesProvider
 import com.datadog.kmp.rum.tracking.ViewTrackingStrategy
@@ -63,6 +65,41 @@ fun RumConfiguration.Builder.trackUserInteractions(
 ): RumConfiguration.Builder {
     nativePlatformBuilder
         .trackUserInteractions(touchTargetExtraAttributesProviders, interactionPredicate)
+    return this
+}
+
+/**
+ * Sets a predicate to filter which Activities are considered for app startup
+ * Time To Initial Display (TTID) measurement.
+ *
+ * Use this to exclude "interstitial Activities" - Activities that are launched during
+ * app startup but immediately launch another Activity in their onCreate() method and
+ * call finish() on themselves (e.g., splash screens, authentication screens).
+ * These Activities may never draw a frame, which can prevent TTID from being reported.
+ *
+ * By default, all Activities are included in TTID measurement.
+ *
+ * **Performance Note:** The predicate is called on the main thread for every Activity
+ * during app startup. Ensure the implementation is fast and doesn't perform expensive
+ * operations.
+ *
+ * Example:
+ * ```
+ * .setAppStartupActivityPredicate { activity ->
+ *     // Exclude AuthenticationActivity from TTID measurement
+ *     activity !is AuthenticationActivity
+ * }
+ * ```
+ *
+ * @param predicate The [AppStartupActivityPredicate] to determine which Activities
+ * should be measured for app startup TTID.
+ * @see [AppStartupActivityPredicate]
+ */
+@ExperimentalRumApi
+fun RumConfiguration.Builder.setAppStartupActivityPredicate(
+    predicate: AppStartupActivityPredicate
+): RumConfiguration.Builder {
+    nativePlatformBuilder.setAppStartupActivityPredicate(predicate)
     return this
 }
 

--- a/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilder.kt
+++ b/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilder.kt
@@ -9,6 +9,7 @@ package com.datadog.kmp.rum.configuration.internal
 import android.content.Context
 import android.view.View
 import com.datadog.android.api.SdkCore
+import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.kmp.event.EventMapper
 import com.datadog.kmp.rum.configuration.RumSessionListener
 import com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
@@ -18,6 +19,7 @@ import com.datadog.kmp.rum.model.ErrorEvent
 import com.datadog.kmp.rum.model.LongTaskEvent
 import com.datadog.kmp.rum.model.ResourceEvent
 import com.datadog.kmp.rum.model.toCommonModel
+import com.datadog.kmp.rum.startup.AppStartupActivityPredicate
 import com.datadog.kmp.rum.tracking.InteractionPredicate
 import com.datadog.kmp.rum.tracking.ViewAttributesProvider
 import com.datadog.kmp.rum.tracking.ViewTrackingStrategy
@@ -197,6 +199,13 @@ internal class AndroidRumConfigurationBuilder : PlatformRumConfigurationBuilder<
             touchTargetExtraAttributesProviders.map { it.native }.toTypedArray(),
             interactionPredicate.native
         )
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    fun setAppStartupActivityPredicate(predicate: AppStartupActivityPredicate) {
+        nativeConfigurationBuilder.setAppStartupActivityPredicate {
+            predicate.shouldTrackStartup(it)
+        }
     }
 
     override fun build(): NativeAndroidConfiguration {

--- a/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/startup/AppStartupActivityPredicate.kt
+++ b/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/startup/AppStartupActivityPredicate.kt
@@ -1,0 +1,47 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.rum.startup
+
+import android.app.Activity
+
+/**
+ * Predicate to determine which Activities should be considered for app startup
+ * Time To Initial Display (TTID) reporting.
+ *
+ * During application launch the SDK tracks the first `Activity` that is created and uses
+ * the time it draws its first frame to compute the TTID value. Use this if you want to skip
+ * some Activities and instead make the SDK consider the 2nd, 3rd Activity's first frame.
+ * Example use cases are:
+ * 1. Splash screens implemented as `Activity`.
+ * 2. Activities that launch another Activity in their `onCreate()` method and call `finish()` on themselves.
+ *
+ * **Performance Note:** This predicate is called for every Activity during app startup.
+ * Ensure the implementation is lightweight and doesn't perform expensive operations
+ * (e.g., disk I/O, network calls, heavy computations).
+ *
+ * Example usage:
+ * ```
+ * RumConfiguration.Builder(applicationId)
+ *     .setAppStartupActivityPredicate { activity ->
+ *         // Exclude authentication and splash activities from TTID measurement
+ *         activity !is AuthenticationActivity && activity !is SplashActivity
+ *     }
+ *     .build()
+ * ```
+ */
+fun interface AppStartupActivityPredicate {
+    /**
+     * Determines whether the given Activity should be considered for TTID measurement.
+     *
+     * This method is called on the main thread during Activity creation. Keep the
+     * implementation fast and avoid blocking operations.
+     *
+     * @param activity The Activity being evaluated during app startup.
+     * @return true if this Activity should be included in TTID measurement, false to exclude it.
+     */
+    fun shouldTrackStartup(activity: Activity): Boolean
+}

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilderTest.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilderTest.kt
@@ -6,8 +6,10 @@
 
 package com.datadog.kmp.rum.configuration.internal
 
+import android.app.Activity
 import android.content.Context
 import android.view.View
+import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.kmp.event.EventMapper
 import com.datadog.kmp.rum.configuration.RumSessionListener
 import com.datadog.kmp.rum.configuration.VitalsUpdateFrequency
@@ -16,6 +18,7 @@ import com.datadog.kmp.rum.model.ActionEvent
 import com.datadog.kmp.rum.model.ErrorEvent
 import com.datadog.kmp.rum.model.LongTaskEvent
 import com.datadog.kmp.rum.model.ResourceEvent
+import com.datadog.kmp.rum.startup.AppStartupActivityPredicate
 import com.datadog.kmp.rum.tracking.InteractionPredicate
 import com.datadog.kmp.rum.tracking.ViewAttributesProvider
 import com.datadog.kmp.rum.tracking.ViewTrackingStrategy
@@ -55,6 +58,7 @@ import com.datadog.android.rum.model.ErrorEvent as NativeErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent as NativeLongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent as NativeResourceEvent
 import com.datadog.android.rum.model.ViewEvent as NativeViewEvent
+import com.datadog.android.rum.startup.AppStartupActivityPredicate as NativeAppStartupActivityPredicate
 import com.datadog.android.rum.tracking.InteractionPredicate as NativeInteractionPredicate
 import com.datadog.android.rum.tracking.ViewAttributesProvider as NativeViewAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy as NativeViewTrackingStrategy
@@ -436,6 +440,25 @@ internal class AndroidRumConfigurationBuilderTest {
 
         // Then
         verify(mockNativeRumConfigurationBuilder).useCustomEndpoint(fakeCustomEndpoint)
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M call platform RUM configuration builder+setAppStartupActivityPredicate W setAppStartupActivityPredicate`() {
+        // Given
+        val mockPredicate = mock<AppStartupActivityPredicate>()
+        val mockActivity = mock<Activity>()
+
+        // When
+        testedBuilder.setAppStartupActivityPredicate(mockPredicate)
+
+        // Then
+        val predicateCaptor = argumentCaptor<NativeAppStartupActivityPredicate>()
+        verify(mockNativeRumConfigurationBuilder)
+            .setAppStartupActivityPredicate(predicateCaptor.capture())
+
+        predicateCaptor.firstValue.shouldTrackStartup(mockActivity)
+        verify(mockPredicate).shouldTrackStartup(mockActivity)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Brings support of https://github.com/DataDog/dd-sdk-android/pull/3173 for the Android-specific configuration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

