### PR TITLE
RUM-15873: Lazy capture of RUM monitor in Ktor instrumentation

### DIFF
--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt
@@ -39,7 +39,7 @@ fun datadogKtorPlugin(
     rumResourceAttributesProvider: RumResourceAttributesProvider = DefaultRumResourceAttributesProvider
 ): ClientPlugin<Unit> {
     return DatadogKtorPlugin(
-        RumMonitor.get(),
+        { RumMonitor.get() },
         RumSessionProvider.get(),
         DatadogContextProvider.get(),
         tracedHosts,

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPlugin.kt
@@ -35,7 +35,7 @@ import io.ktor.http.contentLength
 import io.ktor.util.AttributeKey
 
 internal class DatadogKtorPlugin(
-    private val rumMonitor: RumMonitor,
+    private val rumMonitorProvider: () -> RumMonitor,
     private val rumSessionProvider: RumSessionProvider,
     private val datadogContextProvider: DatadogContextProvider,
     private val tracedHosts: Map<String, Set<TracingHeaderType>>,
@@ -93,7 +93,7 @@ internal class DatadogKtorPlugin(
         val requestId = uuid4().toString()
         request.attributes.put(DD_REQUEST_ID_ATTR, requestId)
         request.attributes.put(DD_IS_SAMPLED_ATTR, isSampledIn)
-        rumMonitor.startResource(
+        rumMonitorProvider.invoke().startResource(
             key = requestId,
             method = request.method.asRumMethod(),
             url = request.url.buildString(),
@@ -115,7 +115,7 @@ internal class DatadogKtorPlugin(
                     put(RUM_RULE_PSR, rulePsr)
                 }
             }
-            rumMonitor.stopResource(
+            rumMonitorProvider.invoke().stopResource(
                 key = requestId,
                 statusCode = response.status.value,
                 size = response.contentLength(), // TODO RUM-6382 Report content size if header is missing
@@ -132,7 +132,7 @@ internal class DatadogKtorPlugin(
         if (requestId != null) {
             val method = request.method
             val url = request.url.toString()
-            rumMonitor.stopResourceWithError(
+            rumMonitorProvider.invoke().stopResourceWithError(
                 key = requestId,
                 statusCode = null,
                 message = "Ktor request error $method $url",

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
@@ -96,7 +96,7 @@ class DatadogKtorPluginTest {
     private var fakeAccountId = nullable(uuid4().toString())
 
     private var testedPlugin = DatadogKtorPlugin(
-        rumMonitor = mockRumMonitor,
+        rumMonitorProvider = { mockRumMonitor },
         tracedHosts = fakeTracedHosts,
         traceSampler = mockTraceSampler,
         traceContextInjection = TraceContextInjection.All,
@@ -878,7 +878,7 @@ class DatadogKtorPluginTest {
     fun `M not inject any tracing headers W request is made + sampled out + sampled injection control`() {
         // Given
         val testedPlugin = DatadogKtorPlugin(
-            rumMonitor = mockRumMonitor,
+            rumMonitorProvider = { mockRumMonitor },
             tracedHosts = fakeTracedHosts,
             traceSampler = mockTraceSampler,
             traceContextInjection = TraceContextInjection.Sampled,
@@ -936,7 +936,7 @@ class DatadogKtorPluginTest {
     fun `M inject tracing headers W request is made + sampled in + sampled injection control`() {
         // Given
         val testedPlugin = DatadogKtorPlugin(
-            rumMonitor = mockRumMonitor,
+            rumMonitorProvider = { mockRumMonitor },
             tracedHosts = fakeTracedHosts,
             traceSampler = mockTraceSampler,
             traceContextInjection = TraceContextInjection.Sampled,
@@ -1070,7 +1070,7 @@ class DatadogKtorPluginTest {
         // Given
         val fakeWildcardTracHeaderTypes = randomEnumValues<TracingHeaderType>()
         val plugin = DatadogKtorPlugin(
-            rumMonitor = mockRumMonitor,
+            rumMonitorProvider = { mockRumMonitor },
             tracedHosts = fakeTracedHosts + mapOf("*" to fakeWildcardTracHeaderTypes),
             traceSampler = mockTraceSampler,
             traceContextInjection = TraceContextInjection.All,


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/DataDog/dd-sdk-kotlin-multiplatform/issues/261.

Don't capture RUM monitor at the plugin creation time, but rather access it when needed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

