### PR TITLE
RUM-16582: Update Detekt and ktlint tooling, static analysis template version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,16 @@
 # Copyright 2016-Present Datadog, Inc.
 
 [*.{kt,kts}]
-ktlint_code_style = android_studio
 ij_kotlin_allow_trailing_comma_on_call_site = false
 ij_kotlin_allow_trailing_comma = false
 ij_kotlin_imports_layout=*,java.**,javax.**,kotlin.**,^
+ktlint_code_style = android_studio
+ktlint_function_naming_ignore_when_annotated_with = Composable
+ktlint_standard_class-signature = disabled
+ktlint_standard_condition-wrapping = disabled
+ktlint_standard_enum-wrapping = disabled
+ktlint_standard_function-expression-body = disabled
+ktlint_standard_function-signature = disabled
+ktlint_standard_property-naming = disabled
+ktlint_standard_statement-wrapping = disabled
 max_line_length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ sdk_classpath
 
 # Generated .podspec files
 **/*.podspec
+
+# Local CI tooling binaries
+.static-checks-tooling/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ static-analysis-ios:
 static-analysis-android:
   stage: analysis
   variables:
-    DETEKT_PUBLIC_API: "false"
+    DETEKT_PUBLIC_API: "true"
     DETEKT_CUSTOM_RULES_BUILD_TASK: ""
     DETEKT_CUSTOM_RULES_JAR_PATH: ""
     DETEKT_CUSTOM_RULES_YML_PATH: ""
@@ -91,7 +91,7 @@ static-analysis-android:
     DETEKT_CLASSPATH_FILE_PATH: ""
     FLAVORED_ANDROID_LINT: ""
   trigger:
-    include: "https://gitlab-templates.ddbuild.io/mobile/v34714656-060be019/static-analysis.yml"
+    include: "https://gitlab-templates.ddbuild.io/mobile/v116514400-1bd68e6b/static-analysis.yml"
     strategy: depend
 
 analysis:licenses:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,16 +154,16 @@ atomic, with a proper commit message.
 ### Code quality
 
 Our code uses [Detekt](https://detekt.dev/) static analysis with a shared configuration, which is slightly
-stricter than the default one. A Detekt check is run on every on every PR to ensure that all new code
+stricter than the default one. A Detekt check is run on every PR to ensure that all new code
 follow this rule.
-Current Detekt version: 1.23.4
+Current Detekt version: 1.23.8
 
 ### Code style
 
 Our coding style is ensured by [KtLint](https://ktlint.github.io/), with the
 default settings. A KtLint check is run on every PR to ensure that all new code
 follow this rule.
-Current KtLint version: 0.50.0
+Current KtLint version: 1.5.0
 
 Classes should group their methods in folding regions named after the declaring
 class. Private methods should be grouped in an `Internal` named folding region.

--- a/core/src/androidUnitTest/kotlin/com/datadog/kmp/internal/BasicProxyAuthenticatorTest.kt
+++ b/core/src/androidUnitTest/kotlin/com/datadog/kmp/internal/BasicProxyAuthenticatorTest.kt
@@ -94,7 +94,8 @@ class BasicProxyAuthenticatorTest {
     ) {
         // Given
         whenever(mockResponse.code) doReturn forge.anElementFrom(
-            forge.anInt(min = 100, max = 407), forge.anInt(min = 408, max = 600)
+            forge.anInt(min = 100, max = 407),
+            forge.anInt(min = 408, max = 600)
         )
 
         // When

--- a/core/src/commonMain/kotlin/com/datadog/kmp/internal/DatadogContextProvider.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/internal/DatadogContextProvider.kt
@@ -12,10 +12,20 @@ import com.datadog.kmp.Datadog
  * This is internal API and shouldn't be used by the clients.
  */
 interface DatadogContextProvider {
+    /**
+     * Current User ID.
+     */
     val userId: String?
+
+    /**
+     * Current Account ID.
+     */
     val accountId: String?
 
     companion object {
+        /**
+         * Creates a default instance of [DatadogContextProvider].
+         */
         fun get(): DatadogContextProvider = object : DatadogContextProvider {
             override val userId: String?
                 get() = Datadog.currentUserId

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/RumResourceKind.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/RumResourceKind.kt
@@ -12,17 +12,59 @@ package com.datadog.kmp.rum
  */
 enum class RumResourceKind {
     // Specific kind of JS resources loading
+    /**
+     * Beacon type resource.
+     */
     BEACON,
+
+    /**
+     * Fetch type resource.
+     */
     FETCH,
+
+    /**
+     * XHR type resource.
+     */
     XHR,
+
+    /**
+     * Document type resource.
+     */
     DOCUMENT,
 
     // Common kinds
+    /**
+     * Native type resource.
+     */
     NATIVE,
+
+    /**
+     * Image type resource.
+     */
     IMAGE,
+
+    /**
+     * JS type resource.
+     */
     JS,
+
+    /**
+     * Font type resource.
+     */
     FONT,
+
+    /**
+     * CSS type resource.
+     */
     CSS,
+
+    /**
+     * Media type resource.
+     */
     MEDIA,
+
+    /**
+     * Other type resource.
+     */
     OTHER
 }

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumSessionProvider.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumSessionProvider.kt
@@ -31,8 +31,14 @@ internal object InternalRumSessionProviderListener : RumSessionProvider, Advance
     }
 }
 
+/**
+ * For the internal usage only.
+ */
 interface RumSessionProvider {
 
+    /**
+     * Current RUM session ID.
+     */
     val sessionId: String?
 
     companion object {

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaderType.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaderType.kt
@@ -44,6 +44,8 @@ enum class TracingHeaderType {
      * @param traceId the trace id
      * @param spanId the span id
      * @param rumSessionId the RUM session id
+     * @param userId the current user ID
+     * @param accountId the current account ID
      */
     internal fun injectHeaders(
         request: HttpRequestBuilder,

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/HeadersExt.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/internal/HeadersExt.kt
@@ -102,6 +102,7 @@ internal fun HeadersBuilder.addToW3cBaggage(key: String, value: String) {
  * ; whitespace, DQUOTE, comma, semicolon,
  * ; and backslash
  */
+@Suppress("EndOfSentenceFormat")
 private val ALLOWED_BAGGAGE_VALUE_CHARS =
     setOf('!') + ('#'..'+') + ('-'..':') + ('<'..'[') + (']'..'~')
 

--- a/local_ci.sh
+++ b/local_ci.sh
@@ -2,6 +2,13 @@
 
 local_ci_usage="Usage: local_ci.sh [-s|--setup] [-n|--clean] [-a|--analysis] [-c|--compile] [-t|--test] [-h|--help]"
 
+KTLINT_VERSION="1.5.0"
+DETEKT_VERSION="1.23.8"
+
+TOOLING_DIR="$(cd "$(dirname "$0")" && pwd)/.static-checks-tooling"
+KTLINT="$TOOLING_DIR/ktlint-$KTLINT_VERSION"
+DETEKT="$TOOLING_DIR/detekt-cli-$DETEKT_VERSION/bin/detekt-cli"
+
 SETUP=0
 CLEANUP=0
 ANALYSIS=0
@@ -47,24 +54,113 @@ done
 # exit on errors
 set -e
 
+# Syncs detekt-common.yml and detekt-public-api.yml from dd-source into config/ at the
+# revision pinned by .gitlab-ci.yml. The dd-source repo is restored
+# to its prior state afterwards so switching branches there can't affect our checks.
+sync_detekt_configs() {
+  local config_dir="config"
+  local pipeline_file=".gitlab-ci.yml"
+  local stamp_file="$config_dir/detekt_dd-source_config.stamp"
+  local detekt_common_config="$config_dir/detekt-common.yml"
+  local detekt_public_api_config="$config_dir/detekt-public-api.yml"
+
+  mkdir -p "$config_dir"
+
+  local version
+  version=$(grep -oE 'gitlab-templates\.ddbuild\.io/mobile/v[0-9]+-[0-9a-f]+/static-analysis\.yml' "$pipeline_file" \
+    | head -1 \
+    | sed -E 's|.*/mobile/(v[0-9]+-[0-9a-f]+)/.*|\1|')
+
+  if [ -z "$version" ]; then
+    echo "  Could not extract dd-source detekt template version from $pipeline_file"
+    exit 1
+  fi
+
+  # Template tag format: vXXXX-${CI_COMMIT_SHA:0:8}
+  local sha="${version##*-}"
+
+  local current=""
+  if [ -f "$stamp_file" ]; then
+    current=$(cat "$stamp_file")
+  fi
+
+  if [ "$current" = "$version" ] && [ -f "$detekt_common_config" ] && [ -f "$detekt_public_api_config" ]; then
+    echo "  Detekt configs already at $version"
+    return 0
+  fi
+
+  echo "  Detekt configs out of date (have '${current:-none}', want '$version'); syncing from dd-source"
+
+  if [ -z "$DD_SOURCE" ]; then
+    echo "  DD_SOURCE not set. Please set it to your local dd-source checkout."
+    echo "  E.g.: export DD_SOURCE=/Volumes/Dev/ci/dd-source"
+    exit 1
+  fi
+  if [ ! -d "$DD_SOURCE/.git" ]; then
+    echo "  DD_SOURCE ($DD_SOURCE) is not a git repository"
+    exit 1
+  fi
+
+  local sdk_dir
+  sdk_dir=$(pwd)
+
+  (
+    cd "$DD_SOURCE"
+
+    orig_ref=$(git symbolic-ref --short -q HEAD || git rev-parse HEAD)
+    stashed=0
+
+    restore_dd_source() {
+      git checkout --quiet "$orig_ref" 2>/dev/null || true
+      if [ "$stashed" = "1" ]; then
+        git stash pop --quiet 2>/dev/null \
+          || echo "  Warning: could not restore stash in $DD_SOURCE; check 'git stash list'"
+      fi
+    }
+    trap restore_dd_source EXIT
+
+    if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+      git stash push -u -m "dd-sdk-android-detekt-sync" > /dev/null
+      stashed=1
+    fi
+
+    git fetch --quiet origin main
+    if ! git checkout --quiet "$sha" 2>/dev/null; then
+      echo "  Could not check out $sha in $DD_SOURCE — make sure dd-source main is up to date"
+      exit 1
+    fi
+
+    cp "domains/mobile/config/android/gitlab/detekt/detekt-common.yml" "$sdk_dir/$detekt_common_config"
+    cp "domains/mobile/config/android/gitlab/detekt/detekt-public-api.yml" "$sdk_dir/$detekt_public_api_config"
+  )
+
+  echo "$version" > "$stamp_file"
+  echo "  Detekt configs synced to $version"
+}
+
 if [[ $SETUP == 1 ]]; then
   echo "-- SETUP"
 
+  mkdir -p "$TOOLING_DIR"
+
   echo "---- Install KtLint"
-  if [[ -x "$(command -v ktlint)" ]]; then
-      echo "  KtLint already installed; version $(ktlint --version)"
+  if [[ -x "$KTLINT" ]]; then
+    echo "  KtLint $KTLINT_VERSION already installed"
   else
-    curl -SLO https://github.com/pinterest/ktlint/releases/download/0.50.0/ktlint && chmod a+x ktlint
-    sudo mv ktlint /usr/local/bin/
-    echo "  KtLint installed; version $(ktlint --version)"
+    curl -SL "https://github.com/pinterest/ktlint/releases/download/$KTLINT_VERSION/ktlint" -o "$KTLINT"
+    chmod a+x "$KTLINT"
+    echo "  KtLint $KTLINT_VERSION installed"
   fi
 
   echo "---- Install Detekt"
-  if [[ -x "$(command -v detekt)" ]]; then
-      echo "  Detekt already installed; version $(detekt --version)"
+  if [[ -x "$DETEKT" ]]; then
+    echo "  Detekt $DETEKT_VERSION already installed"
   else
-    brew install detekt
-    echo "  Detekt installed; version $(detekt --version)"
+    curl -SL "https://github.com/detekt/detekt/releases/download/v$DETEKT_VERSION/detekt-cli-$DETEKT_VERSION.zip" -o "$TOOLING_DIR/detekt-cli-$DETEKT_VERSION.zip"
+    unzip "$TOOLING_DIR/detekt-cli-$DETEKT_VERSION.zip" -d "$TOOLING_DIR"
+    chmod a+x "$TOOLING_DIR/detekt-cli-$DETEKT_VERSION/bin/detekt-cli"
+    rm -rf "$TOOLING_DIR/detekt-cli-$DETEKT_VERSION.zip"
+    echo "  Detekt $DETEKT_VERSION installed"
   fi
 fi
 
@@ -87,25 +183,30 @@ fi
 if [[ $ANALYSIS == 1 ]]; then
   echo "-- STATIC ANALYSIS"
 
-  echo "---- KtLint"
-  ktlint -F "**/*.kt" "**/*.kts" '!**/build/generated/**' '!**/build/kspCaches/**'
-
-  echo "---- Detekt"
-  if [ -z $DD_SOURCE ]; then
-    echo "Can't run shared Detekt, missing dd_source repository path."
-    echo "Please set the path to your local dd_source repository in the DD_SOURCE environment variable."
-    echo "E.g.: "
-    echo "$ export DD_SOURCE=/Volumes/Dev/ci/dd-source"
-    exit 1
+  echo "---- KtLint (changed files only)"
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$CURRENT_BRANCH" = "develop" ]; then
+    # On develop: check uncommitted + staged changes
+    CHANGED_KT_FILES=$(git diff --name-only --diff-filter=d HEAD -- '*.kt' '*.kts' | grep -v 'build/generated/' | grep -v 'build/kspCaches/' || true)
   else
-    echo "Using Detekt rules from $DD_SOURCE folder"
+    # On feature branch: check all changes vs develop (committed + uncommitted)
+    CHANGED_KT_FILES=$( (git diff --name-only --diff-filter=d develop... -- '*.kt' '*.kts'; git diff --name-only --diff-filter=d HEAD -- '*.kt' '*.kts') | sort -u | grep -v 'build/generated/' | grep -v 'build/kspCaches/' || true)
+  fi
+  if [ -n "$CHANGED_KT_FILES" ]; then
+    echo "$CHANGED_KT_FILES" | xargs "$KTLINT" -F
+  else
+    echo "  No changed .kt/.kts files, skipping"
   fi
 
-  echo "------ Detekt common rules"
-  detekt --config "$DD_SOURCE/domains/mobile/config/android/gitlab/detekt/detekt-common.yml"
+  echo "---- Detekt"
+  echo "------ Sync Detekt configs from dd-source"
+  sync_detekt_configs
 
-  # echo "------ Detekt public API rules"
-  # detekt --config "$DD_SOURCE/domains/mobile/config/android/gitlab/detekt/detekt-public-api.yml"
+  echo "------ Detekt common rules"
+  "$DETEKT" --parallel --config "config/detekt-common.yml"
+
+  echo "------ Detekt public API rules"
+  "$DETEKT" --parallel --config "config/detekt-public-api.yml" --excludes "**/model/*.kt,**/build/**"
 
   echo "---- AndroidLint"
   ./gradlew :lintCheckAll

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/apisurface/GenerateApiSurfaceTask.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/apisurface/GenerateApiSurfaceTask.kt
@@ -18,7 +18,7 @@ open class GenerateApiSurfaceTask : DefaultTask() {
     @get:InputFiles
     lateinit var sourceFiles: FileCollection
 
-    @get: OutputFile
+    @get:OutputFile
     lateinit var surfaceFile: File
 
     private lateinit var visitor: KotlinFileVisitor

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/gitclone/GitCloneDependenciesTask.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/gitclone/GitCloneDependenciesTask.kt
@@ -19,7 +19,7 @@ open class GitCloneDependenciesTask @Inject constructor(
     private val execOperations: ExecOperations
 ) : DefaultTask() {
 
-    @get: Input
+    @get:Input
     var extension: GitCloneDependenciesExtension =
         GitCloneDependenciesExtension()
 

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/GenerateJsonSchemaPlugin.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/jsonschema/GenerateJsonSchemaPlugin.kt
@@ -60,7 +60,7 @@ class GenerateJsonSchemaPlugin : Plugin<Project> {
                 target.tasks.withType<Jar> {
                     dependsOn(modelsGenerationTask)
                 }
-                target.tasks.withType<KotlinCompileCommon>() {
+                target.tasks.withType<KotlinCompileCommon> {
                     dependsOn(modelsGenerationTask)
                 }
             }

--- a/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/transdeps/TransitiveDependenciesTask.kt
+++ b/tools/build-plugins/src/main/kotlin/com/datadog/build/plugin/transdeps/TransitiveDependenciesTask.kt
@@ -24,7 +24,7 @@ open class TransitiveDependenciesTask : DefaultTask() {
     @get:Input
     var sortByName: Boolean = true
 
-    @get: OutputFiles
+    @get:OutputFiles
     var outputFiles: List<File> = mutableListOf()
 
     init {


### PR DESCRIPTION
### What does this PR do?

This PR bumps static analysis template, Detekt and ktlint versions used.

As part of this change, `local_ci.sh` is also update to pull Detekt templates and install ktlint/Detekt in the local folder, so that we don't request sudo.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

