### PR TITLE
RUM-16586: Add configuration option to collect accessibility properties in RUM

### DIFF
--- a/features/rum/api/commonMain/apiSurface
+++ b/features/rum/api/commonMain/apiSurface
@@ -84,6 +84,7 @@ class com.datadog.kmp.rum.configuration.RumConfiguration
     fun setLongTaskEventMapper(com.datadog.kmp.event.EventMapper<com.datadog.kmp.rum.model.LongTaskEvent>): Builder
     fun trackAnonymousUser(Boolean): Builder
     fun useCustomEndpoint(String): Builder
+    fun collectAccessibility(Boolean): Builder
     fun build(): RumConfiguration
 fun interface com.datadog.kmp.rum.configuration.RumSessionListener
   fun onSessionStarted(String, Boolean)

--- a/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilder.kt
+++ b/features/rum/src/androidMain/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilder.kt
@@ -185,6 +185,10 @@ internal class AndroidRumConfigurationBuilder : PlatformRumConfigurationBuilder<
         nativeConfigurationBuilder.useCustomEndpoint(endpoint)
     }
 
+    override fun collectAccessibility(enabled: Boolean) {
+        nativeConfigurationBuilder.collectAccessibility(enabled)
+    }
+
     fun trackNonFatalAnrs(enabled: Boolean) {
         nativeConfigurationBuilder.trackNonFatalAnrs(enabled)
     }

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilderTest.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/configuration/internal/AndroidRumConfigurationBuilderTest.kt
@@ -444,6 +444,17 @@ internal class AndroidRumConfigurationBuilderTest {
         verify(mockNativeRumConfigurationBuilder).useCustomEndpoint(fakeCustomEndpoint)
     }
 
+    @Test
+    fun `M call platform RUM configuration builder+collectAccessibility W collectAccessibility`(
+        @BoolForgery fakeEnabled: Boolean
+    ) {
+        // When
+        testedBuilder.collectAccessibility(fakeEnabled)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).collectAccessibility(fakeEnabled)
+    }
+
     @OptIn(ExperimentalRumApi::class)
     @Test
     fun `M call platform RUM configuration builder+setAppStartupActivityPredicate W setAppStartupActivityPredicate`() {

--- a/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/configuration/internal/AppleRumConfigurationBuilder.kt
+++ b/features/rum/src/appleMain/kotlin/com/datadog/kmp/rum/configuration/internal/AppleRumConfigurationBuilder.kt
@@ -255,6 +255,10 @@ internal abstract class AppleRumConfigurationBuilder : PlatformRumConfigurationB
         nativeConfiguration.setCustomEndpoint(NSURL.URLWithString(endpoint))
     }
 
+    override fun collectAccessibility(enabled: Boolean) {
+        nativeConfiguration.setCollectAccessibility(enabled)
+    }
+
     fun setUiKitViewsPredicate(uiKitViewsPredicate: UIKitRUMViewsPredicate) {
         val nativePredicate = if (uiKitViewsPredicate is DefaultUIKitRUMViewsPredicate) {
             // just a short path to avoid creating unnecessary layers. NB: if DefaultUIKitRUMViewsPredicate becomes

--- a/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/configuration/internal/AppleRumConfigurationBuilderTest.kt
+++ b/features/rum/src/appleTest/kotlin/com/datadog/kmp/rum/configuration/internal/AppleRumConfigurationBuilderTest.kt
@@ -425,6 +425,18 @@ internal abstract class AppleRumConfigurationBuilderTest<T : AppleRumConfigurati
     }
 
     @Test
+    fun `M set collect accessibility W collectAccessibility`() {
+        // Given
+        val fakeEnabled = randomBoolean()
+
+        // When
+        testedBuilder.collectAccessibility(fakeEnabled)
+
+        // Then
+        assertEquals(fakeEnabled, fakeNativeRumConfiguration.collectAccessibility())
+    }
+
+    @Test
     fun `M set memory warnings tracking W trackMemoryWarnings`() {
         // Given
         val fakeTrackMemoryWarnings = randomBoolean()

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/RumConfiguration.kt
@@ -205,6 +205,16 @@ class RumConfiguration internal constructor(internal val nativeConfiguration: An
         }
 
         /**
+         * Whether to collect accessibility attributes - this is disabled by default.
+         *
+         * @param enabled whether collecting accessibility attributes is enabled or not.
+         */
+        fun collectAccessibility(enabled: Boolean): Builder {
+            platformBuilder.collectAccessibility(enabled)
+            return this
+        }
+
+        /**
          * Builds a [RumConfiguration] based on the current state of this Builder.
          */
         fun build(): RumConfiguration {

--- a/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/internal/PlatformRumConfigurationBuilder.kt
+++ b/features/rum/src/commonMain/kotlin/com/datadog/kmp/rum/configuration/internal/PlatformRumConfigurationBuilder.kt
@@ -46,5 +46,7 @@ internal interface PlatformRumConfigurationBuilder<out T : Any> {
 
     fun useCustomEndpoint(endpoint: String)
 
+    fun collectAccessibility(enabled: Boolean)
+
     fun build(): T
 }

--- a/features/rum/src/commonTest/kotlin/com/datadog/kmp/rum/configuration/RumConfigurationBuilderTest.kt
+++ b/features/rum/src/commonTest/kotlin/com/datadog/kmp/rum/configuration/RumConfigurationBuilderTest.kt
@@ -246,4 +246,18 @@ class RumConfigurationBuilderTest {
             mockPlatformRumConfigurationBuilder.useCustomEndpoint(fakeCustomEndpoint)
         }
     }
+
+    @Test
+    fun `M call platform RUM configuration builder+collectAccessibility W collectAccessibility`() {
+        // Given
+        val fakeEnabled = true
+
+        // When
+        testedRumConfigurationBuilder.collectAccessibility(fakeEnabled)
+
+        // Then
+        verify {
+            mockPlatformRumConfigurationBuilder.collectAccessibility(fakeEnabled)
+        }
+    }
 }


### PR DESCRIPTION
### What does this PR do?

A new configuration option to explicitly control accessibility properties collection.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

