### PR TITLE
RUM-16575: Add `isLowRam`, `logicalCpuCount`, `totalRam` device properties for Logs and RUM

### DIFF
--- a/features/logs/api/commonMain/apiSurface
+++ b/features/logs/api/commonMain/apiSurface
@@ -43,7 +43,7 @@ data class com.datadog.kmp.log.model.LogEvent
   data class Os
     constructor(kotlin.String, kotlin.String, kotlin.String? = null, kotlin.String)
   data class LogEventDevice
-    constructor(Type? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    constructor(Type? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
   data class Logger
     constructor(kotlin.String, kotlin.String)
   data class Dd

--- a/features/logs/src/androidUnitTest/kotlin/com/datadog/kmp/log/utils/forge/LogEventForgeryFactory.kt
+++ b/features/logs/src/androidUnitTest/kotlin/com/datadog/kmp/log/utils/forge/LogEventForgeryFactory.kt
@@ -114,7 +114,13 @@ internal class LogEventForgeryFactory : ForgeryFactory<LogEvent> {
                 type = forge.aNullable { aValueFrom(LogEvent.Type::class.java) },
                 name = forge.aNullable { anAlphabeticalString() },
                 model = forge.aNullable { anAlphabeticalString() },
-                brand = forge.aNullable { anAlphabeticalString() }
+                brand = forge.aNullable { anAlphabeticalString() },
+                isLowRam = forge.aNullable { aBool() },
+                logicalCpuCount = forge.aNullable { anInt(min = 1, max = 9) },
+                totalRam = forge.aNullable {
+                    // 1GB to 16GB
+                    aLong(min = 1_073_741_824, max = 17_179_869_185)
+                }
             ),
             os = LogEvent.Os(
                 name = forge.aString(),

--- a/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/model/internal/LogEventMappingExt.kt
+++ b/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/model/internal/LogEventMappingExt.kt
@@ -95,12 +95,14 @@ internal fun DDLogEventDd.toCommonModel(): LogEvent.Dd = LogEvent.Dd(
 )
 
 internal fun DDLogEventDevice.toCommonModel(): LogEvent.LogEventDevice = LogEvent.LogEventDevice(
-    // TODO RUM-15734 add isLowRam, logicalCpuCount, totalRam once available in iOS SDK
     architecture = architecture(),
     type = logEventDeviceTypeToCommonEnum(type()),
     name = name(),
     model = model(),
-    brand = brand()
+    brand = brand(),
+    logicalCpuCount = logicalCpuCount()?.doubleValue,
+    totalRam = totalRam()?.doubleValue,
+    isLowRam = isLowRam()?.boolValue
 )
 
 internal fun DDLogEventDDDevice.toCommonModel(): LogEvent.DdDevice = LogEvent.DdDevice(

--- a/features/logs/src/commonMain/json/log/log-schema.json
+++ b/features/logs/src/commonMain/json/log/log-schema.json
@@ -61,6 +61,21 @@
           "type": "string",
           "description": "The CPU architecture of the device that is reporting the error",
           "readOnly": true
+        },
+        "logical_cpu_count": {
+          "type": "number",
+          "description": "Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.",
+          "readOnly": true
+        },
+        "total_ram": {
+          "type": "number",
+          "description": "Total RAM in megabytes",
+          "readOnly": true
+        },
+        "is_low_ram": {
+          "type": "boolean",
+          "description": "Whether the device is considered a low RAM device (Android)",
+          "readOnly": true
         }
       }
     },

--- a/features/rum/api/commonMain/apiSurface
+++ b/features/rum/api/commonMain/apiSurface
@@ -131,7 +131,7 @@ data class com.datadog.kmp.rum.model.ActionEvent
   data class Os
     constructor(kotlin.String, kotlin.String, kotlin.String? = null, kotlin.String)
   data class Device
-    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
   data class Dd
     constructor(DdSession? = null, Configuration? = null, kotlin.String? = null, DdAction? = null)
     val formatVersion: kotlin.Long
@@ -248,7 +248,7 @@ data class com.datadog.kmp.rum.model.ErrorEvent
   data class Os
     constructor(kotlin.String, kotlin.String, kotlin.String? = null, kotlin.String)
   data class Device
-    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
   data class Dd
     constructor(DdSession? = null, Configuration? = null, kotlin.String? = null, Profiling? = null)
     val formatVersion: kotlin.Long
@@ -425,7 +425,7 @@ data class com.datadog.kmp.rum.model.LongTaskEvent
   data class Os
     constructor(kotlin.String, kotlin.String, kotlin.String? = null, kotlin.String)
   data class Device
-    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
   data class Dd
     constructor(DdSession? = null, Configuration? = null, kotlin.String? = null, kotlin.Boolean? = null, Profiling? = null)
     val formatVersion: kotlin.Long
@@ -533,7 +533,7 @@ data class com.datadog.kmp.rum.model.ResourceEvent
   data class Os
     constructor(kotlin.String, kotlin.String, kotlin.String? = null, kotlin.String)
   data class Device
-    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
   data class Dd
     constructor(DdSession? = null, Configuration? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Boolean? = null)
     val formatVersion: kotlin.Long
@@ -688,7 +688,7 @@ data class com.datadog.kmp.rum.model.ViewEvent
   data class Os
     constructor(kotlin.String, kotlin.String, kotlin.String? = null, kotlin.String)
   data class Device
-    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    constructor(DeviceType? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
   data class Dd
     constructor(DdSession? = null, Configuration? = null, kotlin.String? = null, kotlin.Long, kotlin.collections.List<PageState>? = null, ReplayStats? = null, Profiling? = null)
     val formatVersion: kotlin.Long

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ActionEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ActionEventForgeryFactory.kt
@@ -102,7 +102,13 @@ internal class ActionEventForgeryFactory :
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(ActionEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    isLowRam = forge.aNullable { aBool() },
+                    logicalCpuCount = forge.aNullable { anInt(min = 1, max = 9) },
+                    totalRam = forge.aNullable {
+                        // 1GB to 16GB
+                        aLong(min = 1_073_741_824, max = 17_179_869_185)
+                    }
                 )
             },
             context = forge.aNullable {

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ErrorEventForgeryFactory.kt
@@ -123,7 +123,13 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(ErrorEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    isLowRam = forge.aNullable { aBool() },
+                    logicalCpuCount = forge.aNullable { anInt(min = 1, max = 9) },
+                    totalRam = forge.aNullable {
+                        // 1GB to 16GB
+                        aLong(min = 1_073_741_824, max = 17_179_869_185)
+                    }
                 )
             },
             context = forge.aNullable {

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/LongTaskEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/LongTaskEventForgeryFactory.kt
@@ -90,7 +90,13 @@ internal class LongTaskEventForgeryFactory :
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(LongTaskEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    isLowRam = forge.aNullable { aBool() },
+                    logicalCpuCount = forge.aNullable { anInt(min = 1, max = 9) },
+                    totalRam = forge.aNullable {
+                        // 1GB to 16GB
+                        aLong(min = 1_073_741_824, max = 17_179_869_185)
+                    }
                 )
             },
             context = forge.aNullable {

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ResourceEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ResourceEventForgeryFactory.kt
@@ -165,7 +165,13 @@ internal class ResourceEventForgeryFactory :
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(ResourceEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    isLowRam = forge.aNullable { aBool() },
+                    logicalCpuCount = forge.aNullable { anInt(min = 1, max = 9) },
+                    totalRam = forge.aNullable {
+                        // 1GB to 16GB
+                        aLong(min = 1_073_741_824, max = 17_179_869_185)
+                    }
                 )
             },
             context = forge.aNullable {

--- a/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/rum/src/androidUnitTest/kotlin/com/datadog/kmp/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -122,7 +122,13 @@ internal class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(ViewEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    isLowRam = forge.aNullable { aBool() },
+                    logicalCpuCount = forge.aNullable { anInt(min = 1, max = 9) },
+                    totalRam = forge.aNullable {
+                        // 1GB to 16GB
+                        aLong(min = 1_073_741_824, max = 17_179_869_185)
+                    }
                 )
             },
             context = forge.aNullable {

--- a/features/rum/src/commonMain/json/rum/_common-schema.json
+++ b/features/rum/src/commonMain/json/rum/_common-schema.json
@@ -308,6 +308,21 @@
           "type": "string",
           "description": "The CPU architecture of the device that is reporting the error",
           "readOnly": true
+        },
+        "logical_cpu_count": {
+          "type": "number",
+          "description": "Number of logical CPU cores available for scheduling on the device at runtime, as reported by the operating system.",
+          "readOnly": true
+        },
+        "total_ram": {
+          "type": "number",
+          "description": "Total RAM in megabytes",
+          "readOnly": true
+        },
+        "is_low_ram": {
+          "type": "boolean",
+          "description": "Whether the device is considered a low RAM device (Android)",
+          "readOnly": true
         }
       }
     },


### PR DESCRIPTION
### What does this PR do?

This PR brings new device properties for Logs and RUM models.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

