### PR TITLE
Zero-pad B3 trace and span IDs to fixed hex width

### DIFF
--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaderType.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaderType.kt
@@ -140,7 +140,11 @@ enum class TracingHeaderType {
         // remove pre-existing if any
         remove(B3_HEADER_KEY)
         if (sampledIn) {
-            append(B3_HEADER_KEY, "${traceId.toHexString()}-${spanId.toHexString()}-1")
+            append(
+                B3_HEADER_KEY,
+                "${traceId.toHexString().padStart(B3_TRACE_ID_LENGTH, '0')}-" +
+                    "${spanId.toHexString().padStart(B3_SPAN_ID_LENGTH, '0')}-1"
+            )
         } else {
             append(B3_HEADER_KEY, B3_DROP_SAMPLING_DECISION)
         }
@@ -156,8 +160,8 @@ enum class TracingHeaderType {
         remove(B3M_SPAN_ID_KEY)
         remove(B3M_SAMPLING_PRIORITY_KEY)
         if (sampledIn) {
-            append(B3M_TRACE_ID_KEY, traceId.toHexString())
-            append(B3M_SPAN_ID_KEY, spanId.toHexString())
+            append(B3M_TRACE_ID_KEY, traceId.toHexString().padStart(B3_TRACE_ID_LENGTH, '0'))
+            append(B3M_SPAN_ID_KEY, spanId.toHexString().padStart(B3_SPAN_ID_LENGTH, '0'))
             append(B3M_SAMPLING_PRIORITY_KEY, B3M_KEEP_SAMPLING_DECISION)
         } else {
             append(B3M_SAMPLING_PRIORITY_KEY, B3M_DROP_SAMPLING_DECISION)

--- a/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaders.kt
+++ b/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/TracingHeaders.kt
@@ -31,6 +31,10 @@ internal const val B3M_SAMPLING_PRIORITY_KEY = "X-B3-Sampled"
 internal const val B3M_DROP_SAMPLING_DECISION = "0"
 internal const val B3M_KEEP_SAMPLING_DECISION = "1"
 
+// B3 (single and multiple) require fixed-width lower-hex ids.
+internal const val B3_TRACE_ID_LENGTH = 32
+internal const val B3_SPAN_ID_LENGTH = 16
+
 // taken from W3CHttpCodec
 internal const val W3C_TRACEPARENT_KEY = "traceparent"
 internal const val W3C_TRACESTATE_KEY = "tracestate"

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/TracingHeaderTypeTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/TracingHeaderTypeTest.kt
@@ -186,7 +186,7 @@ class TracingHeaderTypeTest {
                 fakeUserId,
                 fakeAccountId
             ) to buildMap {
-                put("b3", "539-2a-1")
+                put("b3", "00000000000000000000000000000539-000000000000002a-1")
             },
             Fixture(
                 TraceId(1234567890u, 1337u),
@@ -196,7 +196,7 @@ class TracingHeaderTypeTest {
                 fakeUserId,
                 fakeAccountId
             ) to buildMap {
-                put("b3", "499602d20000000000000539-2a-1")
+                put("b3", "00000000499602d20000000000000539-000000000000002a-1")
             },
             Fixture(
                 TraceId(ULong.MAX_VALUE, ULong.MAX_VALUE),
@@ -253,8 +253,8 @@ class TracingHeaderTypeTest {
                 fakeUserId,
                 fakeAccountId
             ) to buildMap {
-                put("X-B3-TraceId", "539")
-                put("X-B3-SpanId", "2a")
+                put("X-B3-TraceId", "00000000000000000000000000000539")
+                put("X-B3-SpanId", "000000000000002a")
                 put("X-B3-Sampled", "1")
             },
             Fixture(
@@ -265,8 +265,8 @@ class TracingHeaderTypeTest {
                 fakeUserId,
                 fakeAccountId
             ) to buildMap {
-                put("X-B3-TraceId", "499602d20000000000000539")
-                put("X-B3-SpanId", "2a")
+                put("X-B3-TraceId", "00000000499602d20000000000000539")
+                put("X-B3-SpanId", "000000000000002a")
                 put("X-B3-Sampled", "1")
             },
             Fixture(

--- a/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
+++ b/integrations/ktor/src/commonTest/kotlin/com/datadog/kmp/ktor/internal/plugin/DatadogKtorPluginTest.kt
@@ -1129,20 +1129,14 @@ class DatadogKtorPluginTest {
     private fun expectedSpanId(spanIdDec: String, headerType: TracingHeaderType): String {
         return when (headerType) {
             TracingHeaderType.DATADOG -> spanIdDec
-            else -> spanIdDec.toULong().toString(HEX_RADIX).lowercase().let {
-                if (headerType == TracingHeaderType.TRACECONTEXT) {
-                    it.padStart(16, '0')
-                } else {
-                    it
-                }
-            }
+            else -> spanIdDec.toULong().toString(HEX_RADIX).lowercase().padStart(16, '0')
         }
     }
 
     private fun expectedTraceId(traceIdHex: String, headerType: TracingHeaderType): String {
         return when (headerType) {
-            TracingHeaderType.TRACECONTEXT -> traceIdHex.padStart(32, '0')
-            else -> traceIdHex
+            TracingHeaderType.DATADOG -> traceIdHex
+            else -> traceIdHex.padStart(32, '0')
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Zero-pads B3 trace and span IDs so the injected `X-B3-TraceId`, `X-B3-SpanId`, and single `b3` headers are always fixed-width hex (16 for the span, 16 or 32 for the trace), per the [B3 spec](https://github.com/openzipkin/b3-propagation). `SpanId.toHexString()` and `TraceId.toHexString()` used `raw.toString(16)` without padding, so an id with a leading-zero nibble was emitted short (e.g. span `0x0ab280a5a3c93643` went out as `ab280a5a3c93643`, 15 chars). The B3 unit tests are updated to the padded expectations.

### Motivation

Found while adding Kotlin Multiplatform to RUM FIT, the cross-SDK integration test suite: the B3 distributed-tracing test failed for KMP while Browser, iOS, and Android passed, since those SDKs pad to fixed width and the KMP Ktor integration did not. 

### Additional Notes

Only B3 output changes. The W3C `traceparent` path already pads at the call site and the Datadog headers use decimal, so both are unaffected. Full `:integrations:ktor` unit tests pass locally.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)
