### PR TITLE
Update wrong `textAndInputPrivacy` API doc in Session Replay and enable accessibility collection in the sample app

### DIFF
--- a/features/session-replay/src/commonMain/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfiguration.kt
+++ b/features/session-replay/src/commonMain/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfiguration.kt
@@ -59,7 +59,7 @@ data class SessionReplayConfiguration internal constructor(
 
         /**
          * Sets the text and input recording level for the Session Replay feature.
-         * If not specified then sensitive text will be masked by default.
+         * If not specified then all text will be masked by default.
          * @see TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
          * @see TextAndInputPrivacy.MASK_ALL_INPUTS
          * @see TextAndInputPrivacy.MASK_ALL

--- a/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
+++ b/sample/shared/src/commonMain/kotlin/com/datadog/kmp/sample/Utils.kt
@@ -82,6 +82,7 @@ fun initDatadog(context: Any? = null) {
         .trackLongTasks()
         .trackFrustrations(true)
         .trackAnonymousUser(true)
+        .collectAccessibility(true)
         .apply {
             setupRumMappers()
         }


### PR DESCRIPTION
### What does this PR do?

* Counterpart of https://github.com/DataDog/dd-sdk-android/pull/3520
* Enable accessibility collection in the sample app

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

