### PR TITLE
RUM-16681: Use `arc4random` for the seed generation on iOS

### DIFF
--- a/integrations/ktor/src/appleMain/kotlin/com/datadog/kmp/ktor/RandomExt.ios.kt
+++ b/integrations/ktor/src/appleMain/kotlin/com/datadog/kmp/ktor/RandomExt.ios.kt
@@ -6,14 +6,32 @@
 
 package com.datadog.kmp.ktor
 
-import platform.Foundation.NSCalendar
-import platform.Foundation.NSCalendarUnitNanosecond
-import platform.Foundation.NSDate
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import platform.posix.arc4random_buf
 import kotlin.random.Random
 
-internal actual val RNG: Random = Random(
-    NSCalendar.currentCalendar.component(
-        unit = NSCalendarUnitNanosecond,
-        fromDate = NSDate()
-    )
-)
+internal actual val RNG: Random = AppleSystemRandom
+
+private object AppleSystemRandom : Random() {
+
+    override fun nextBits(bitCount: Int): Int {
+        if (bitCount == 0) return 0
+
+        val value = memScoped {
+            val bytes = allocArray<UByteVar>(Int.SIZE_BYTES)
+            arc4random_buf(bytes, Int.SIZE_BYTES.convert())
+
+            var result = 0
+            repeat(Int.SIZE_BYTES) { index ->
+                result = result or (bytes[index].toInt() shl (index * Byte.SIZE_BITS))
+            }
+            result
+        }
+
+        return value ushr (Int.SIZE_BITS - bitCount)
+    }
+}

--- a/integrations/ktor/src/appleTest/kotlin/com/datadog/kmp/ktor/RandomExtTest.kt
+++ b/integrations/ktor/src/appleTest/kotlin/com/datadog/kmp/ktor/RandomExtTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.ktor
+
+import com.datadog.tools.random.randomInt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class RandomExtTest {
+
+    @Test
+    fun `M fill lower bits first W nextBits`() {
+        // Given
+        val bitCount = randomInt(from = 8, until = 25)
+
+        // When
+        val value = RNG.nextBits(bitCount)
+
+        // Then
+        assertEquals(0, value ushr bitCount)
+        assertNotEquals(0, value shl Int.SIZE_BITS - bitCount)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Tiny improvement to use https://linux.die.net/man/3/arc4random_buf on iOS for the seed generation.

This matches then `SecureRandom` usage on Android side.

The current approach is to use nanosecond-precision timestamp, which still have a very small chance of collisions then between two devices.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

