### PR TITLE
Use signed images in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # SETUP
 
 variables:
-  CURRENT_CI_IMAGE: "8"
+  CURRENT_CI_IMAGE: "9"
   CI_IMAGE_DOCKER: registry.ddbuild.io/ci/dd-sdk-kotlin-multiplatform:$CURRENT_CI_IMAGE
   SLACK_NOTIFIER_IMAGE: registry.ddbuild.io/slack-notifier:latest
   GIT_DEPTH: 6
@@ -45,9 +45,14 @@ ci-image:
   when: manual
   except: [ tags, schedules ]
   tags: [ "arch:amd64" ]
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-jammy
   script:
-    - docker buildx build --tag $CI_IMAGE_DOCKER --label target=build -f Dockerfile.gitlab --push .
+    - METADATA_FILE=$(mktemp)
+    - docker buildx build --tag $CI_IMAGE_DOCKER --label target=build -f Dockerfile.gitlab --push --metadata-file ${METADATA_FILE} .
+    - ddsign sign $CI_IMAGE_DOCKER --docker-metadata-file ${METADATA_FILE}
 
 env-info:
   stage: info
@@ -91,7 +96,7 @@ static-analysis-android:
     DETEKT_CLASSPATH_FILE_PATH: ""
     FLAVORED_ANDROID_LINT: ""
   trigger:
-    include: "https://gitlab-templates.ddbuild.io/mobile/v116514400-1bd68e6b/static-analysis.yml"
+    include: "https://gitlab-templates.ddbuild.io/mobile/v123745390-227cb48b/static-analysis.yml"
     strategy: depend
 
 analysis:licenses:

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -107,3 +107,6 @@ RUN npm install -g @datadog/datadog-ci
 ENV DD_TRACER_FOLDER $PWD/dd-java-agent
 RUN mkdir -p $DD_TRACER_FOLDER
 RUN wget -O $DD_TRACER_FOLDER/dd-java-agent.jar https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_TRACER_VERSION/dd-java-agent-$DD_TRACER_VERSION.jar
+
+# Install ddsign for image signing
+COPY --from=registry.ddbuild.io/ddsign:v1.11.10@sha256:55784668a612ab22129bb15a665a847819bfa64b9a595c59a03a3a725534ce22 /usr/local/bin/ddsign /usr/local/bin/ddsign


### PR DESCRIPTION
### What does this PR do?
Signs our CI image and upgrades the shared pipeline that already uses a signed image for the analysis jobs
