### PR TITLE
RUM-17871: Add `UK1` datacenter support

### DIFF
--- a/core/api/commonMain/apiSurface
+++ b/core/api/commonMain/apiSurface
@@ -18,6 +18,7 @@ enum com.datadog.kmp.DatadogSite
   - EU1
   - AP1
   - AP2
+  - UK1
   - US1_FED
   - US2_FED
 enum com.datadog.kmp.SdkLogVerbosity

--- a/core/src/androidHostTest/kotlin/com/datadog/kmp/DatadogExtTest.kt
+++ b/core/src/androidHostTest/kotlin/com/datadog/kmp/DatadogExtTest.kt
@@ -101,7 +101,8 @@ internal class DatadogExtTest {
             DatadogSite.US5 to DatadogSiteAndroid.US5,
             DatadogSite.EU1 to DatadogSiteAndroid.EU1,
             DatadogSite.AP1 to DatadogSiteAndroid.AP1,
-            DatadogSite.AP2 to DatadogSiteAndroid.AP2
+            DatadogSite.AP2 to DatadogSiteAndroid.AP2,
+            DatadogSite.UK1 to DatadogSiteAndroid.UK1
         )
             .assertExhaustive(DatadogSite.entries)
             .assertAllKeysEqualToValuesWhen { it.native }

--- a/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -299,4 +299,5 @@ internal val DatadogSite.native: DatadogSiteAndroid
         DatadogSite.EU1 -> DatadogSiteAndroid.EU1
         DatadogSite.AP1 -> DatadogSiteAndroid.AP1
         DatadogSite.AP2 -> DatadogSiteAndroid.AP2
+        DatadogSite.UK1 -> DatadogSiteAndroid.UK1
     }

--- a/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -312,6 +312,7 @@ private val DatadogSite.native: DDSite
         DatadogSite.EU1 -> DDSite.eu1()
         DatadogSite.AP1 -> DDSite.ap1()
         DatadogSite.AP2 -> DDSite.ap2()
+        DatadogSite.UK1 -> DDSite.uk1()
     }
 
 private fun Map<String, Any?>.eraseKeyType(): Map<Any?, *> {

--- a/core/src/commonMain/kotlin/com/datadog/kmp/DatadogSite.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/DatadogSite.kt
@@ -42,6 +42,11 @@ enum class DatadogSite {
     AP2,
 
     /**
+     *  The UK1 site: [uk1.datadoghq.com](https://uk1.datadoghq.com).
+     */
+    UK1,
+
+    /**
      *  The US1_FED site (FedRAMP compatible): [app.ddog-gov.com](https://app.ddog-gov.com).
      */
     US1_FED,


### PR DESCRIPTION
### What does this PR do?

Waiting for https://github.com/DataDog/dd-sdk-ios/pull/3087 to be released.

This PR adds `uk1` datacenter support.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

