### PR TITLE
RUM-17869: Add `Configuration#setVersion` API

### DIFF
--- a/core/api/commonMain/apiSurface
+++ b/core/api/commonMain/apiSurface
@@ -43,6 +43,7 @@ data class com.datadog.kmp.core.configuration.Configuration
     fun setBatchProcessingLevel(BatchProcessingLevel): Builder
     fun trackCrashes(Boolean): Builder
     fun setProxy(ProxyConfiguration): Builder
+    fun setVersion(String): Builder
 class com.datadog.kmp.core.configuration.ProxyConfiguration
   constructor(ProxyType, String, UInt)
   fun withBasicAuthentication(String, String): ProxyConfiguration

--- a/core/src/androidHostTest/kotlin/com/datadog/kmp/DatadogExtTest.kt
+++ b/core/src/androidHostTest/kotlin/com/datadog/kmp/DatadogExtTest.kt
@@ -15,6 +15,7 @@ import com.datadog.kmp.internal.InternalAttributes
 import com.datadog.kmp.privacy.TrackingConsent
 import com.datadog.kmp.tools.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -127,11 +128,86 @@ internal class DatadogExtTest {
                     InternalAttributes.SDK_VERSION_ATTRIBUTE
                 )
             )
+            .apply {
+                coreConfig.version?.let { setVersion(it) }
+            }
             .setProxy(coreConfig.proxyConfiguration)
             .build()
 
         // When
         val actualConfiguration = sdkConfiguration.native
+
+        // Then
+        assertThat(actualConfiguration).isEqualTo(expectedConfiguration)
+    }
+
+    @Test
+    fun `M set version on native configuration W Configuration_native { version provided }`(
+        @Forgery sdkConfiguration: Configuration,
+        @StringForgery fakeVersion: String
+    ) {
+        // Given
+        val configuration = sdkConfiguration.copy(
+            coreConfig = sdkConfiguration.coreConfig.copy(version = fakeVersion)
+        )
+        val expectedConfiguration = ConfigurationAndroid.Builder(
+            clientToken = configuration.clientToken,
+            env = configuration.env,
+            variant = configuration.variant,
+            service = configuration.service
+        )
+            .useSite(configuration.coreConfig.site.native)
+            .setBatchSize(configuration.coreConfig.batchSize.native)
+            .setUploadFrequency(configuration.coreConfig.uploadFrequency.native)
+            .setBatchProcessingLevel(configuration.coreConfig.batchProcessingLevel.native)
+            .setCrashReportsEnabled(configuration.coreConfig.trackCrashes)
+            .setAdditionalConfiguration(
+                mapOf(
+                    InternalAttributes.SOURCE_ATTRIBUTE,
+                    InternalAttributes.SDK_VERSION_ATTRIBUTE
+                )
+            )
+            .setVersion(fakeVersion)
+            .setProxy(configuration.coreConfig.proxyConfiguration)
+            .build()
+
+        // When
+        val actualConfiguration = configuration.native
+
+        // Then
+        assertThat(actualConfiguration).isEqualTo(expectedConfiguration)
+    }
+
+    @Test
+    fun `M not set version on native configuration W Configuration_native { version not provided }`(
+        @Forgery sdkConfiguration: Configuration
+    ) {
+        // Given
+        val configuration = sdkConfiguration.copy(
+            coreConfig = sdkConfiguration.coreConfig.copy(version = null)
+        )
+        val expectedConfiguration = ConfigurationAndroid.Builder(
+            clientToken = configuration.clientToken,
+            env = configuration.env,
+            variant = configuration.variant,
+            service = configuration.service
+        )
+            .useSite(configuration.coreConfig.site.native)
+            .setBatchSize(configuration.coreConfig.batchSize.native)
+            .setUploadFrequency(configuration.coreConfig.uploadFrequency.native)
+            .setBatchProcessingLevel(configuration.coreConfig.batchProcessingLevel.native)
+            .setCrashReportsEnabled(configuration.coreConfig.trackCrashes)
+            .setAdditionalConfiguration(
+                mapOf(
+                    InternalAttributes.SOURCE_ATTRIBUTE,
+                    InternalAttributes.SDK_VERSION_ATTRIBUTE
+                )
+            )
+            .setProxy(configuration.coreConfig.proxyConfiguration)
+            .build()
+
+        // When
+        val actualConfiguration = configuration.native
 
         // Then
         assertThat(actualConfiguration).isEqualTo(expectedConfiguration)

--- a/core/src/androidHostTest/kotlin/com/datadog/kmp/tools/forge/ConfigurationForgeryFactory.kt
+++ b/core/src/androidHostTest/kotlin/com/datadog/kmp/tools/forge/ConfigurationForgeryFactory.kt
@@ -23,6 +23,7 @@ internal class ConfigurationForgeryFactory : ForgeryFactory<Configuration> {
             site = forge.aValueFrom(DatadogSite::class.java),
             batchProcessingLevel = forge.aValueFrom(BatchProcessingLevel::class.java),
             trackCrashes = forge.aBool(),
+            version = forge.aNullable { forge.aString() },
             proxyConfiguration = forge.aNullable {
                 ProxyConfiguration(
                     type = forge.aValueFrom(ProxyType::class.java),

--- a/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/androidMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -252,6 +252,11 @@ internal val Configuration.native: ConfigurationAndroid
                     InternalAttributes.SDK_VERSION_ATTRIBUTE
                 )
             )
+            .apply {
+                coreConfig.version?.let {
+                    setVersion(it)
+                }
+            }
             .setProxy(coreConfig.proxyConfiguration)
             .build()
     }

--- a/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
+++ b/core/src/appleMain/kotlin/com/datadog/kmp/Datadog.kt
@@ -268,6 +268,7 @@ internal val Configuration.native: DDConfiguration
                 InternalAttributes.SDK_VERSION_ATTRIBUTE
             )
         )
+        nativeConfig.setVersion(coreConfig.version)
         nativeConfig.setProxy(coreConfig.proxyConfiguration)
         nativeConfig.setBackgroundTasksEnabled(coreConfig.backgroundTasksEnabled)
         return nativeConfig

--- a/core/src/appleTest/kotlin/com/datadog/kmp/DatadogExtTest.kt
+++ b/core/src/appleTest/kotlin/com/datadog/kmp/DatadogExtTest.kt
@@ -31,6 +31,7 @@ import com.datadog.tools.random.randomEnumValue
 import com.datadog.tools.random.randomUInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Suppress("FunctionNaming")
@@ -86,6 +87,7 @@ internal class DatadogExtTest {
 
     @Test
     fun `M return expected configuration W Configuration_native`() {
+        // Given
         val expectedProxyConfig = mapOf(
             "HTTPSEnable" to true,
             "HTTPSProxy" to "hostname",
@@ -104,6 +106,7 @@ internal class DatadogExtTest {
                     hostname = expectedProxyConfig["HTTPSProxy"] as String,
                     port = expectedProxyConfig["HTTPSPort"] as UInt
                 ),
+                version = "version",
                 backgroundTasksEnabled = randomBoolean()
             ),
             clientToken = "clientToken",
@@ -113,8 +116,10 @@ internal class DatadogExtTest {
 
         )
 
+        // When
         val nativeConfig = commonConfig.native
 
+        // Then
         nativeConfig.proxyConfiguration()
             ?.assertAllKeysEqualToValuesWhen { expectedProxyConfig[it] }
 
@@ -122,10 +127,38 @@ internal class DatadogExtTest {
         assertEquals(commonConfig.coreConfig.uploadFrequency.native, nativeConfig.uploadFrequency())
         assertEquals(commonConfig.coreConfig.batchProcessingLevel.native, nativeConfig.batchProcessingLevel())
         assertEquals(commonConfig.coreConfig.backgroundTasksEnabled, nativeConfig.backgroundTasksEnabled())
+        assertEquals(commonConfig.coreConfig.version, nativeConfig.version())
         assertEquals(commonConfig.clientToken, nativeConfig.clientToken())
         assertEquals(commonConfig.env, nativeConfig.env())
         assertEquals(commonConfig.service, nativeConfig.service())
         // TODO RUM-8122: support site equality verification
+    }
+
+    @Test
+    fun `M return null version on native configuration W Configuration_native without version`() {
+        // Given
+        val commonConfig = Configuration(
+            coreConfig = Configuration.Core(
+                batchSize = randomEnumValue(),
+                uploadFrequency = randomEnumValue(),
+                site = randomEnumValue(),
+                batchProcessingLevel = randomEnumValue(),
+                trackCrashes = randomBoolean(),
+                proxyConfiguration = null,
+                version = null,
+                backgroundTasksEnabled = randomBoolean()
+            ),
+            clientToken = "clientToken",
+            env = "env",
+            variant = "variant",
+            service = "service"
+        )
+
+        // When
+        val nativeConfig = commonConfig.native
+
+        // Then
+        assertNull(nativeConfig.version())
     }
 
     companion object {

--- a/core/src/commonMain/kotlin/com/datadog/kmp/core/configuration/Configuration.kt
+++ b/core/src/commonMain/kotlin/com/datadog/kmp/core/configuration/Configuration.kt
@@ -31,6 +31,7 @@ internal constructor(
         val batchProcessingLevel: BatchProcessingLevel,
         val trackCrashes: Boolean,
         val proxyConfiguration: ProxyConfiguration?,
+        val version: String?,
         // iOS only
         val backgroundTasksEnabled: Boolean
     )
@@ -100,7 +101,7 @@ internal constructor(
         /**
          * Defines the Batch processing level, defining the maximum number of batches processed
          * sequentially without a delay within one reading/uploading cycle.
-         * @param batchProcessingLevel the desired batch processing level. By default it's set to
+         * @param batchProcessingLevel the desired batch processing level. By default, it's set to
          * [BatchProcessingLevel.MEDIUM].
          * @see BatchProcessingLevel
          */
@@ -128,6 +129,17 @@ internal constructor(
             coreConfig = coreConfig.copy(proxyConfiguration = proxyConfiguration)
             return this
         }
+
+        /**
+         * Sets the version name that will be used for all events sent to Datadog.
+         * If not provided, the SDK will use the version from the application's package info.
+         *
+         * @param version the version name to use
+         */
+        fun setVersion(version: String): Builder {
+            coreConfig = coreConfig.copy(version = version)
+            return this
+        }
     }
 
     // endregion
@@ -146,6 +158,7 @@ internal constructor(
             batchProcessingLevel = BatchProcessingLevel.MEDIUM,
             trackCrashes = true,
             proxyConfiguration = null,
+            version = null,
             backgroundTasksEnabled = false
         )
     }


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/DataDog/dd-sdk-kotlin-multiplatform/issues/297.

It is using the related `setVersion` API which was added in:

* iOS SDK https://github.com/DataDog/dd-sdk-ios/pull/2586
* Android SDK https://github.com/DataDog/dd-sdk-android/pull/3137

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

