### PR TITLE
PANA-8572 Add Android heatmaps support

### DIFF
--- a/features/session-replay/api/androidMain/apiSurface
+++ b/features/session-replay/api/androidMain/apiSurface
@@ -5,3 +5,4 @@ actual object com.datadog.kmp.sessionreplay.SessionReplay
 fun SessionReplayConfiguration.Builder.addExtensionSupport(com.datadog.android.sessionreplay.ExtensionSupport): SessionReplayConfiguration.Builder
 fun SessionReplayConfiguration.Builder.setDynamicOptimizationEnabled(Boolean): SessionReplayConfiguration.Builder
 fun SessionReplayConfiguration.Builder.setSystemRequirements(com.datadog.android.sessionreplay.SystemRequirementsConfiguration): SessionReplayConfiguration.Builder
+fun SessionReplayConfiguration.Builder.setHeatmapsEnabled(Boolean): SessionReplayConfiguration.Builder

--- a/features/session-replay/src/androidHostTest/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfigurationExtTest.kt
+++ b/features/session-replay/src/androidHostTest/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfigurationExtTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.kmp.sessionreplay.configuration
+
+import com.datadog.kmp.sessionreplay.configuration.internal.AndroidSessionReplayConfigurationBuilder
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+class SessionReplayConfigurationExtTest {
+
+    @Mock
+    private lateinit var mockPlatformBuilder: AndroidSessionReplayConfigurationBuilder
+
+    @Test
+    fun `M call platform builder and return same builder W setHeatmapsEnabled`(
+        @BoolForgery enabled: Boolean
+    ) {
+        // Given
+        val testedBuilder = SessionReplayConfiguration.Builder(mockPlatformBuilder)
+
+        // When
+        val result = testedBuilder.setHeatmapsEnabled(enabled)
+
+        // Then
+        verify(mockPlatformBuilder).setHeatmapsEnabled(enabled)
+        assertThat(result).isSameAs(testedBuilder)
+    }
+}

--- a/features/session-replay/src/androidHostTest/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/AndroidSessionReplayConfigurationBuilderTest.kt
+++ b/features/session-replay/src/androidHostTest/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/AndroidSessionReplayConfigurationBuilderTest.kt
@@ -119,6 +119,17 @@ class AndroidSessionReplayConfigurationBuilderTest {
     }
 
     @Test
+    fun `M call platform configuration builder+setHeatmapsEnabled W setHeatmapsEnabled`(
+        @BoolForgery enabled: Boolean
+    ) {
+        // When
+        testedBuilder.setHeatmapsEnabled(enabled)
+
+        // Then
+        verify(mockNativeRumConfigurationBuilder).setHeatmapsEnabled(enabled)
+    }
+
+    @Test
     fun `M call platform configuration builder+startRecordingImmediately W startRecordingImmediately`(
         @BoolForgery fakeEnabled: Boolean
     ) {

--- a/features/session-replay/src/androidMain/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfiguration.kt
+++ b/features/session-replay/src/androidMain/kotlin/com/datadog/kmp/sessionreplay/configuration/SessionReplayConfiguration.kt
@@ -53,5 +53,21 @@ fun SessionReplayConfiguration.Builder.setSystemRequirements(
     return this
 }
 
+/**
+ * Enables or disables heatmap data collection for native Android views.
+ *
+ * Heatmaps are disabled by default. To collect the user interactions required for heatmaps,
+ * also enable RUM user interaction tracking with
+ * [com.datadog.kmp.rum.configuration.trackUserInteractions].
+ *
+ * @param enabled whether heatmap data collection is enabled.
+ */
+fun SessionReplayConfiguration.Builder.setHeatmapsEnabled(
+    enabled: Boolean
+): SessionReplayConfiguration.Builder {
+    (platformBuilder as AndroidSessionReplayConfigurationBuilder).setHeatmapsEnabled(enabled)
+    return this
+}
+
 internal actual fun platformConfigurationBuilder(sampleRate: Float): PlatformSessionReplayConfigurationBuilder<*> =
     AndroidSessionReplayConfigurationBuilder(sampleRate)

--- a/features/session-replay/src/androidMain/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/AndroidSessionReplayConfigurationBuilder.kt
+++ b/features/session-replay/src/androidMain/kotlin/com/datadog/kmp/sessionreplay/configuration/internal/AndroidSessionReplayConfigurationBuilder.kt
@@ -40,6 +40,10 @@ internal class AndroidSessionReplayConfigurationBuilder :
         nativeBuilder.setSystemRequirements(systemRequirementsConfiguration)
     }
 
+    fun setHeatmapsEnabled(enabled: Boolean) {
+        nativeBuilder.setHeatmapsEnabled(enabled)
+    }
+
     override fun setImagePrivacy(privacy: ImagePrivacy) {
         nativeBuilder.setImagePrivacy(privacy.native)
     }

--- a/sample/shared/src/androidMain/kotlin/com/datadog/kmp/sample/Utils.android.kt
+++ b/sample/shared/src/androidMain/kotlin/com/datadog/kmp/sample/Utils.android.kt
@@ -20,6 +20,7 @@ import com.datadog.kmp.sessionreplay.configuration.SessionReplayConfiguration
 import com.datadog.kmp.sessionreplay.configuration.TextAndInputPrivacy
 import com.datadog.kmp.sessionreplay.configuration.TouchPrivacy
 import com.datadog.kmp.sessionreplay.configuration.addExtensionSupport
+import com.datadog.kmp.sessionreplay.configuration.setHeatmapsEnabled
 import com.datadog.kmp.webview.WebViewTracking
 
 internal actual fun platformSpecificSetup(rumConfigurationBuilder: RumConfiguration.Builder) {
@@ -52,6 +53,7 @@ internal actual fun initSessionReplay() {
             .setImagePrivacy(ImagePrivacy.MASK_LARGE_ONLY)
             .setTouchPrivacy(TouchPrivacy.SHOW)
             .setTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
+            .setHeatmapsEnabled(true)
             .addExtensionSupport(ComposeExtensionSupport())
             .build()
     )


### PR DESCRIPTION
### What does this PR do?

Adds Android native heatmap support to the Kotlin Multiplatform Session Replay configuration.

This introduces an Android-only setHeatmapsEnabled builder API that forwards to dd-sdk-android. Heatmaps remain disabled by default and require explicit activation alongside RUM user interaction tracking.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

